### PR TITLE
BTS 229 / GNB 라우터 추가 및 로그아웃 UI 반영

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -5,11 +5,13 @@ import Link from 'next/link';
 
 import { ROUTE } from '@/constants/route';
 import { useSession } from '@/features/auth/hooks/use-session';
-import { useRole } from '@/hooks/use-role';
+import { useLogoutMutation } from '@/features/auth/services/query';
+
+import { DropdownMenu } from '../ui/dropdown-menu';
 
 export const Header = () => {
   const { data: session } = useSession();
-  const { role } = useRole();
+  const { mutate: logout, isPending } = useLogoutMutation();
 
   const roleMetaMap = {
     ROLE_STUDENT: {
@@ -33,7 +35,11 @@ export const Header = () => {
     <header className="h-header-height fixed top-0 right-0 left-0 z-10 flex items-center border-b border-gray-200 bg-[#1A1A1A] px-8">
       <div className="mx-auto flex w-full items-center justify-between">
         <div className="flex items-center gap-2">
-          <Link href={role === undefined ? ROUTE.HOME : ROUTE.DASHBOARD.HOME}>
+          <Link
+            href={
+              session?.auth === undefined ? ROUTE.HOME : ROUTE.DASHBOARD.HOME
+            }
+          >
             <Image
               src={'/logo.svg'}
               alt="THE EDU 로고"
@@ -48,21 +54,32 @@ export const Header = () => {
             width={44}
             height={20}
           />
-          <Link
-            href={ROUTE.DASHBOARD.HOME}
-            className="mx-2 text-white"
-          >
-            대시보드
-          </Link>
-          <Link
-            href=""
-            className="mx-2 text-white"
-          >
-            공지사항
-          </Link>
+          {session?.auth && (
+            <>
+              <Link
+                href={ROUTE.DASHBOARD.HOME}
+                className="mx-2 text-white"
+              >
+                대시보드
+              </Link>
+              <Link
+                href=""
+                className="mx-2 text-white"
+              >
+                공지사항
+              </Link>
+            </>
+          )}
         </div>
-        {role !== undefined && session && (
+        {session?.auth && (
           <div className="flex items-center">
+            <button
+              className="mx-2 cursor-pointer text-white"
+              onClick={() => logout()}
+              disabled={isPending}
+            >
+              로그아웃
+            </button>
             <Image
               src={'/img_header_bell.svg'}
               alt="알림 벨 아이콘"
@@ -70,13 +87,21 @@ export const Header = () => {
               height={24}
               className="mr-8 cursor-pointer"
             />
-            <Image
-              src={'/img_header_profile.svg'}
-              alt="프로필 사진"
-              width={48}
-              height={48}
-              className="desktop:flex mr-4 hidden cursor-pointer rounded-full"
-            />
+
+            <DropdownMenu>
+              <DropdownMenu.Trigger className="flex cursor-pointer items-center justify-center">
+                <Image
+                  src={'/img_header_profile.svg'}
+                  alt="프로필 사진"
+                  width={48}
+                  height={48}
+                  className="desktop:flex mr-4 hidden cursor-pointer rounded-full"
+                />
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content>
+                <DropdownMenu.Item>로그아웃</DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu>
 
             <p className="desktop:flex mr-2 hidden items-center gap-2 text-[14px] font-[600] text-white">
               {session.nickname}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -5,9 +5,11 @@ import Link from 'next/link';
 
 import { ROUTE } from '@/constants/route';
 import { useSession } from '@/features/auth/hooks/use-session';
+import { useRole } from '@/hooks/use-role';
 
 export const Header = () => {
   const { data: session } = useSession();
+  const { role } = useRole();
 
   const roleMetaMap = {
     ROLE_STUDENT: {
@@ -31,7 +33,7 @@ export const Header = () => {
     <header className="h-header-height fixed top-0 right-0 left-0 z-10 flex items-center border-b border-gray-200 bg-[#1A1A1A] px-8">
       <div className="mx-auto flex w-full items-center justify-between">
         <div className="flex items-center gap-2">
-          <Link href={ROUTE.HOME}>
+          <Link href={role === undefined ? ROUTE.HOME : ROUTE.DASHBOARD.HOME}>
             <Image
               src={'/logo.svg'}
               alt="THE EDU 로고"
@@ -46,8 +48,20 @@ export const Header = () => {
             width={44}
             height={20}
           />
+          <Link
+            href={ROUTE.DASHBOARD.HOME}
+            className="mx-2 text-white"
+          >
+            대시보드
+          </Link>
+          <Link
+            href=""
+            className="mx-2 text-white"
+          >
+            공지사항
+          </Link>
         </div>
-        {session && (
+        {role !== undefined && session && (
           <div className="flex items-center">
             <Image
               src={'/img_header_bell.svg'}
@@ -63,18 +77,7 @@ export const Header = () => {
               height={48}
               className="desktop:flex mr-4 hidden cursor-pointer rounded-full"
             />
-            <Link
-              href="/studyrooms/1/studynotes"
-              className="mx-2 text-white"
-            >
-              스터디룸
-            </Link>
-            <Link
-              href="/dashboard/studynote/1"
-              className="mx-2 text-white"
-            >
-              스터디 노트
-            </Link>
+
             <p className="desktop:flex mr-2 hidden items-center gap-2 text-[14px] font-[600] text-white">
               {session.nickname}
             </p>


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
<!-- 
- 변경된 내용에 대해 간략하게 설명해주세요.
- 예: 사용자 로그인 기능 추가
- 예: API 응답 구조 변경 
-->

### DESIGN  
* Header에 "대시보드", "공지사항" 라우팅 UI 추가
* "로그아웃" UI, 프로필 드롭다운 UI 추가

### FUTURE DISCUSSION
* 로그아웃 API 부재로 로그아웃은 UI만 있습니다. 추후에 API 연동이 필요합니다

## 🧐 관련 이슈
<!--
- 관련된 이슈 번호를 적어주세요. (ex. `Closes #123`, `Fixes #456`) 
-->

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->
<img width="1214" height="76" alt="image" src="https://github.com/user-attachments/assets/f6dedf46-8e93-4c0e-b94c-3f8f323f7af7" />


## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
