### PR TITLE
refactor: BTS-228 / 스터디룸 생성 플로우 리팩토링

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,4 +1,42 @@
+import { Metadata } from 'next';
+
 import { EmptyConnectionDialog } from '@/features/dashboard/connect/components/empty-connection-dialog';
+
+const SITE_NAME = '디에듀';
+const SITE_URL = 'https://the-edu.vercel.app/';
+const OG_IMAGE = '/logo.svg';
+
+export const metadata: Metadata = {
+  title: `${SITE_NAME} | 수업·숙제·피드백까지 학습의 흐름을 깔끔하게`,
+  description:
+    '학생·학부모·선생님이 함께 쓰는 스터디룸. 수업 기록과 초대가 쉬워집니다.',
+  metadataBase: new URL(SITE_URL),
+  alternates: { canonical: '/' },
+  // 공통 (카카오톡 / 페이스북 / 디스코드 / 슬랙)
+  openGraph: {
+    type: 'website',
+    url: '/',
+    siteName: SITE_NAME,
+    title: `${SITE_NAME} | 수업·숙제·피드백까지 학습의 흐름을 깔끔하게`,
+    description:
+      '학생·학부모·선생님이 함께 쓰는 스터디룸. 수업 기록과 초대가 쉬워집니다.',
+    images: [
+      {
+        url: OG_IMAGE,
+        width: 1200,
+        height: 630,
+        alt: `${SITE_NAME} 홈 미리보기`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `${SITE_NAME} | 수업·숙제·피드백까지 학습의 흐름을 깔끔하게`,
+    description:
+      '학생·학부모·선생님이 함께 쓰는 스터디룸. 수업 기록과 초대가 쉬워집니다.',
+    images: [OG_IMAGE],
+  },
+};
 
 export default function HomePage() {
   return (

--- a/src/app/(dashboard)/dashboard/study-rooms/page.tsx
+++ b/src/app/(dashboard)/dashboard/study-rooms/page.tsx
@@ -1,3 +1,0 @@
-export default function StudyRoomListPage() {
-  return <main>스터디룸 목록</main>;
-}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  const host = 'https://the-edu.vercel.app';
+
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: ['/'],
+        disallow: [
+          '/login',
+          '/register',
+          '/studyrooms',
+          '/dashboard',
+          '/api',
+          '/_next',
+        ],
+      },
+    ],
+    sitemap: [`${host}/sitemap.xml`],
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: 'https://the-edu.vercel.app/',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+  ];
+}

--- a/src/app/studyrooms/[id]/invite-member/page.tsx
+++ b/src/app/studyrooms/[id]/invite-member/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import React from 'react';
+import { useForm } from 'react-hook-form';
+
+import { ColumnLayout } from '@/components/layout/column-layout';
+import { Sidebar } from '@/components/layout/sidebar';
+import { Button } from '@/components/ui/button';
+import { Form } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { InviteMemberSchema } from '@/features/studyrooms/schemas/invite';
+
+const InviteMemberPage = () => {
+  const methods = useForm<InviteMemberSchema>({});
+
+  const onSubmit = () => {
+    //console.log('submit')
+  };
+  return (
+    <div className="desktop:pl-sidebar-width flex flex-col bg-[#F9F9F9]">
+      <Sidebar />
+      <ColumnLayout className="h-[calc(100vh-theme(space.header-height))] container mx-auto flex flex-col items-center overflow-auto pt-0">
+        <Form
+          onSubmit={methods.handleSubmit(onSubmit)}
+          className="w-3/4"
+        >
+          <Form.Item>
+            <Form.Label className="text-2xl font-semibold">
+              초대할 학생이 있나요?
+            </Form.Label>
+            <Input
+              {...methods.register('emails')}
+              placeholder="초대할 사람을 검색 후 선택해주세요"
+              className="mt-6"
+            />
+          </Form.Item>
+          <ul className="mt-5 space-y-1 text-sm text-gray-600">
+            <li>학생을 초대하면 연결된 보호자는 자동으로 함께 입장합니다.</li>
+            <li>
+              각 수업 노트는 보호자에게 공개하거나 비공개로 설정할 수 있습니다.
+            </li>
+            <li>
+              학생과 연결되지 않은 보호자는 스터디룸에 입장할 수 없습니다.
+            </li>
+          </ul>
+          <div className="mt-10 flex items-center justify-between space-y-4">
+            <p className="text-muted-foreground bg-key-color-secondary mb-0 rounded-md p-2 text-sm">
+              학생을 초대하지 않아도 스터디룸 기능을 먼저 사용할 수 있어요
+            </p>
+            <Button
+              type="submit"
+              className="w-48"
+              disabled={true}
+            >
+              {false ? '생성 중...' : '완료'}
+            </Button>
+          </div>
+        </Form>
+      </ColumnLayout>
+    </div>
+  );
+};
+
+export default InviteMemberPage;

--- a/src/app/studyrooms/[id]/invite-member/page.tsx
+++ b/src/app/studyrooms/[id]/invite-member/page.tsx
@@ -1,61 +1,96 @@
 'use client';
 
 import React from 'react';
-import { useForm } from 'react-hook-form';
+
+import Image from 'next/image';
+import { useParams, useRouter } from 'next/navigation';
 
 import { ColumnLayout } from '@/components/layout/column-layout';
 import { Sidebar } from '@/components/layout/sidebar';
 import { Button } from '@/components/ui/button';
-import { Form } from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
-import { InviteMemberSchema } from '@/features/studyrooms/schemas/invite';
+import { InvitationField } from '@/features/studyrooms/components/student-invitation/InvitationField';
+import { useInvitationController } from '@/features/studyrooms/hooks/useInvitationController';
+import { useSendInvitationMutation } from '@/features/studyrooms/services/query';
 
 const InviteMemberPage = () => {
-  const methods = useForm<InviteMemberSchema>({});
+  const router = useRouter();
+  const params = useParams();
+  const studyRoomId = Number(params.id);
 
-  const onSubmit = () => {
-    //console.log('submit')
+  const invitation = useInvitationController(studyRoomId);
+  const { mutate: sendInvitation, isPending } = useSendInvitationMutation();
+
+  const handleSubmit = () => {
+    const emails = Array.from(invitation.invitees.keys());
+    if (!emails.length) return;
+    sendInvitation(
+      { studyRoomId, emails },
+      {
+        onSuccess: () =>
+          router.replace(`/studyrooms/${studyRoomId}/studynotes`),
+      }
+    );
   };
+
   return (
     <div className="desktop:pl-sidebar-width flex flex-col bg-[#F9F9F9]">
       <Sidebar />
       <ColumnLayout className="h-[calc(100vh-theme(space.header-height))] container mx-auto flex flex-col items-center overflow-auto pt-0">
-        <Form
-          onSubmit={methods.handleSubmit(onSubmit)}
-          className="w-3/4"
-        >
-          <Form.Item>
-            <Form.Label className="text-2xl font-semibold">
-              초대할 학생이 있나요?
-            </Form.Label>
-            <Input
-              {...methods.register('emails')}
-              placeholder="초대할 사람을 검색 후 선택해주세요"
-              className="mt-6"
+        <section className="w-3/4">
+          <h3
+            id="invite-label"
+            className="mb-4 text-2xl font-semibold"
+          >
+            초대할 학생이 있나요?
+          </h3>
+          <InvitationField
+            labelledById="invite-label"
+            invitation={invitation}
+            placeholder="초대할 학생을 검색후 선택해 주세요."
+          />
+          <aside
+            role="note"
+            aria-labelledby="invitation-info-title"
+            className="mt-6 flex items-start gap-2"
+          >
+            <Image
+              src="/common/info.svg"
+              alt="alert"
+              width={20}
+              height={20}
+              className="relative top-[3px]"
             />
-          </Form.Item>
-          <ul className="mt-5 space-y-1 text-sm text-gray-600">
-            <li>학생을 초대하면 연결된 보호자는 자동으로 함께 입장합니다.</li>
-            <li>
-              각 수업 노트는 보호자에게 공개하거나 비공개로 설정할 수 있습니다.
-            </li>
-            <li>
-              학생과 연결되지 않은 보호자는 스터디룸에 입장할 수 없습니다.
-            </li>
-          </ul>
+            <h2
+              id="invitation-info-title"
+              className="sr-only"
+            >
+              사용자(학생)초대 관련 안내
+            </h2>
+            <ul className="space-y-1">
+              <li>학생을 초대하면 연결된 보호자는 자동으로 함께 입장합니다.</li>
+              <li>
+                각 수업 노트는 보호자에게 공개하거나 비공개로 설정할 수
+                있습니다.
+              </li>
+              <li>
+                학생과 연결되지 않은 보호자는 스터디룸에 입장할 수 없습니다.
+              </li>
+            </ul>
+          </aside>
           <div className="mt-10 flex items-center justify-between space-y-4">
             <p className="text-muted-foreground bg-key-color-secondary mb-0 rounded-md p-2 text-sm">
               학생을 초대하지 않아도 스터디룸 기능을 먼저 사용할 수 있어요
             </p>
             <Button
-              type="submit"
-              className="w-48"
-              disabled={true}
+              type="button"
+              className="w-[140px]"
+              disabled={!invitation.invitees.size || isPending}
+              onClick={handleSubmit}
             >
-              {false ? '생성 중...' : '완료'}
+              {isPending ? '초대 중…' : '초대하기'}
             </Button>
           </div>
-        </Form>
+        </section>
       </ColumnLayout>
     </div>
   );

--- a/src/app/studyrooms/create/page.tsx
+++ b/src/app/studyrooms/create/page.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 
 import { ColumnLayout } from '@/components/layout/column-layout';
+import { Sidebar } from '@/components/layout/sidebar';
 import CreateStudyRoomFlow from '@/features/studyrooms/components/create/CreateStudyRoomFlow';
 
 export default function CreateStudyRoomPage() {
   return (
-    <ColumnLayout className="container mx-auto">
-      <CreateStudyRoomFlow />
-    </ColumnLayout>
+    <div className="desktop:pl-sidebar-width flex flex-col bg-[#F9F9F9]">
+      <Sidebar />
+      <ColumnLayout className="container mx-auto">
+        <CreateStudyRoomFlow />
+      </ColumnLayout>
+    </div>
   );
 }

--- a/src/components/dialog/confirm-dialog.tsx
+++ b/src/components/dialog/confirm-dialog.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import React from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Dialog } from '@/components/ui/dialog';
+import { DialogAction } from '@/features/studyrooms/hooks/useDialogReducer';
+import { cn } from '@/lib/utils';
+
+// TODO: 스터디룸/공용 내 다이얼로그 컴포넌트를 공용컴포넌트로 분리해볼 예정
+type ConfirmDialogVariant = 'ok' | 'confirm' | 'confirm-cancel' | 'delete';
+export const ConfirmDialog = ({
+  open,
+  dispatch,
+  variant = 'confirm',
+  title,
+  description,
+  confirmText,
+  cancelText,
+  onConfirm,
+  onCancel,
+  pending = false,
+  emphasis = 'desc-strong',
+}: {
+  open: boolean;
+  dispatch: (action: DialogAction) => void;
+  variant?: ConfirmDialogVariant;
+  title?: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+  pending?: boolean;
+  emphasis?: 'title-strong' | 'desc-strong' | 'none';
+}) => {
+  const isTwoButtons = variant === 'delete' || variant === 'confirm-cancel';
+  const _confirmText =
+    confirmText ??
+    (variant === 'delete' ? '삭제' : variant === 'ok' ? '확인' : '확인');
+  const _cancelText = cancelText ?? (variant === 'delete' ? '취소' : '취소');
+
+  const close = () => dispatch({ type: 'CLOSE' });
+
+  return (
+    <Dialog
+      isOpen={open}
+      onOpenChange={close}
+    >
+      <Dialog.Content className="w-[598px]">
+        <Dialog.Header>
+          {title ? (
+            <Dialog.Title
+              className={cn(
+                'text-center',
+                emphasis === 'title-strong' && 'font-headline1-heading'
+              )}
+            >
+              {title}
+            </Dialog.Title>
+          ) : (
+            <Dialog.Title className="text-center" />
+          )}
+        </Dialog.Header>
+
+        <Dialog.Body className="mt-6">
+          {description && (
+            <Dialog.Description
+              className={cn(
+                'text-center',
+                emphasis === 'desc-strong' &&
+                  'font-headline1-heading font-bold',
+                'font-headline2-normal mt-2'
+              )}
+            >
+              {description}
+            </Dialog.Description>
+          )}
+        </Dialog.Body>
+
+        <Dialog.Footer className="mt-6 justify-center gap-8">
+          {isTwoButtons && (
+            <Button
+              className="w-[120px]"
+              size="xsmall"
+              variant="outlined"
+              onClick={() => {
+                onCancel?.();
+                close();
+              }}
+              disabled={pending}
+            >
+              {_cancelText}
+            </Button>
+          )}
+          <Button
+            className="w-[120px]"
+            size="xsmall"
+            variant={variant === 'delete' ? 'secondary' : 'secondary'}
+            onClick={() => {
+              onConfirm?.();
+              // 확인 후 닫기를 호출부에서 제어하려면 이 줄 제거
+              close();
+            }}
+            disabled={pending}
+          >
+            {_confirmText}
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+};

--- a/src/features/studyrooms/components/create/CreateStudyRoomFlow.tsx
+++ b/src/features/studyrooms/components/create/CreateStudyRoomFlow.tsx
@@ -8,7 +8,6 @@ import { useRouter } from 'next/navigation';
 import { Form } from '@/components/ui/form';
 import ProgressIndicator from '@/features/studyrooms/components/create/ProgressIndicator';
 import StepOne from '@/features/studyrooms/components/create/StepOne';
-import StepThree from '@/features/studyrooms/components/create/StepThree';
 import StepTwo from '@/features/studyrooms/components/create/StepTwo';
 import { useStepValidate } from '@/features/studyrooms/hooks/useStepValidate';
 import {
@@ -23,13 +22,12 @@ import {
 import { useCreateStudyRoomMutation } from '@/features/studyrooms/services/query';
 import { zodResolver } from '@hookform/resolvers/zod';
 
-export const ORDER = ['basic', 'profile', 'invite'] as const;
+export const ORDER = ['basic', 'profile'] as const;
 export type Step = (typeof ORDER)[number];
 
 /**
  * - basic : 스터디룸의 메타데이터
  * - profile : 스터디룸이 어떤 수업을 위한 것인지 설명하는 교육 프로필
- * - invite: 참여자
  **/
 export const fieldsPerStep: Record<Step, FieldPath<StudyRoomFormValues>[]> = {
   basic: ['name', 'visibility', 'description'],
@@ -40,7 +38,6 @@ export const fieldsPerStep: Record<Step, FieldPath<StudyRoomFormValues>[]> = {
     'schoolInfo.schoolLevel',
     'schoolInfo.grade',
   ],
-  invite: ['emails'],
 };
 
 export default function CreateStudyRoomFlow() {
@@ -88,7 +85,7 @@ export default function CreateStudyRoomFlow() {
 
   const onSubmit = (data: StudyRoomFormValues) => {
     mutate(data, {
-      onSuccess: () => router.push('/dashboard'),
+      onSuccess: (data) => router.push(`/studyrooms/${data.id}/invite-member`),
     });
   };
 
@@ -115,13 +112,8 @@ export default function CreateStudyRoomFlow() {
               disabled={!isStepValid}
             />
           )}
-          {step === 'profile' && (
-            <StepTwo
-              onNext={handleNext}
-              disabled={!isStepValid}
-            />
-          )}
-          {step === 'invite' && <StepThree disabled={isPending} />}
+          {step === 'profile' && <StepTwo disabled={isPending} />}
+          {/*{step === 'invite' && <StepThree disabled={isPending} />}*/}
         </Form>
       </FormProvider>
     </section>

--- a/src/features/studyrooms/components/create/CreateStudyRoomFlow.tsx
+++ b/src/features/studyrooms/components/create/CreateStudyRoomFlow.tsx
@@ -85,7 +85,8 @@ export default function CreateStudyRoomFlow() {
 
   const onSubmit = (data: StudyRoomFormValues) => {
     mutate(data, {
-      onSuccess: (data) => router.push(`/studyrooms/${data.id}/invite-member`),
+      onSuccess: (data) =>
+        router.replace(`/studyrooms/${data.id}/invite-member`),
     });
   };
 

--- a/src/features/studyrooms/components/create/StepTwo.tsx
+++ b/src/features/studyrooms/components/create/StepTwo.tsx
@@ -45,7 +45,13 @@ type FileSchema = {
 
 const { data } = step2 as FileSchema;
 
-export default function StepTwo({ disabled }: { disabled?: boolean }) {
+export default function StepTwo({
+  disabled,
+  onRequestSubmit,
+}: {
+  disabled?: boolean;
+  onRequestSubmit?: () => void;
+}) {
   const { control, getValues, setValue } = useFormContext();
   const title = getValues('basic.title') ?? '';
   const school = useWatch({ control, name: 'schoolInfo.schoolLevel' });
@@ -171,9 +177,10 @@ export default function StepTwo({ disabled }: { disabled?: boolean }) {
           작성하신 정보는 더 나은 디에듀 서비스를 제공하는데에 활용됩니다.
         </p>
         <Button
-          type="submit"
+          type="button"
           className="w-48"
           disabled={disabled}
+          onClick={onRequestSubmit}
         >
           {disabled ? '생성 중...' : '완료'}
         </Button>

--- a/src/features/studyrooms/components/create/StepTwo.tsx
+++ b/src/features/studyrooms/components/create/StepTwo.tsx
@@ -9,7 +9,6 @@ import { RadioCard } from '@/components/ui/radio-card';
 import { RadioGroup } from '@/components/ui/radio-group';
 import { Select } from '@/components/ui/select';
 import step2 from '@/features/studyrooms/data/step2.json';
-import { CreateStepForm } from '@/features/studyrooms/types';
 
 type Base = {
   id: string;
@@ -46,7 +45,7 @@ type FileSchema = {
 
 const { data } = step2 as FileSchema;
 
-export default function StepTwo({ onNext, disabled }: CreateStepForm) {
+export default function StepTwo({ disabled }: { disabled?: boolean }) {
   const { control, getValues, setValue } = useFormContext();
   const title = getValues('basic.title') ?? '';
   const school = useWatch({ control, name: 'schoolInfo.schoolLevel' });
@@ -172,12 +171,11 @@ export default function StepTwo({ onNext, disabled }: CreateStepForm) {
           작성하신 정보는 더 나은 디에듀 서비스를 제공하는데에 활용됩니다.
         </p>
         <Button
-          type="button"
+          type="submit"
           className="w-48"
-          onClick={onNext}
           disabled={disabled}
         >
-          다음
+          {disabled ? '생성 중...' : '완료'}
         </Button>
       </div>
     </>

--- a/src/features/studyrooms/components/student-invitation/InvitationField.tsx
+++ b/src/features/studyrooms/components/student-invitation/InvitationField.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 
 import { InvitationChip } from '@/features/studyrooms/components/student-invitation/InvitationChip';
@@ -9,49 +11,63 @@ import { Popover } from './Popover';
 export const InvitationField = ({
   invitation,
   placeholder,
+  labelledById,
 }: {
   invitation: InvitationController;
   placeholder: string;
+  labelledById?: string;
 }) => {
   return (
+    /* Todo: 버튼 내 버튼 중복 콘솔 오류로 임시 child 지정 */
     <Popover>
-      <Popover.Trigger
-        onKeyDown={(e) => {
-          if (
-            (e.key === 'Backspace' || e.key === 'Delete') &&
-            !invitation.isSearch &&
-            invitation.searchQuery.trim() === '' &&
-            invitation.invitees.size > 0
-          ) {
-            e.preventDefault();
-            invitation.removeLast();
-          }
-        }}
-        className="text-text-sub2 border-line-line2 hover:border-key-color-primary focus-visible:ring-key-color-primary mb-4 flex min-h-12 cursor-pointer flex-wrap items-center justify-start gap-2 rounded-[4px] border px-3 py-2 hover:bg-transparent focus:outline-none focus-visible:ring-2 active:bg-transparent"
-      >
-        {invitation.invitees.size === 0 && (
-          <span
-            className="text-gray-500"
-            aria-hidden="true"
-          >
-            {placeholder}
-          </span>
-        )}
-        <ul
-          role="list"
-          aria-label="초대 대상 목록"
-          className="flex min-h-12 flex-wrap gap-2"
+      <Popover.Trigger asChild>
+        <div
+          role="combobox"
+          tabIndex={0}
+          aria-labelledby={labelledById}
+          aria-expanded={invitation.isSearch}
+          aria-controls="invitation-popover"
+          onClick={invitation.openSearch}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              invitation.openSearch();
+            }
+            if (
+              (e.key === 'Backspace' || e.key === 'Delete') &&
+              !invitation.isSearch &&
+              invitation.searchQuery.trim() === '' &&
+              invitation.invitees.size > 0
+            ) {
+              e.preventDefault();
+              invitation.removeLast();
+            }
+          }}
+          className="text-text-sub2 border-line-line2 hover:border-key-color-primary focus-visible:ring-key-color-primary mb-4 flex min-h-12 cursor-pointer flex-wrap items-center justify-start gap-2 rounded-[4px] border px-3 py-2 hover:bg-transparent focus:outline-none focus-visible:ring-2 active:bg-transparent"
         >
-          {Array.from(invitation.invitees.values()).map((u) => (
-            <InvitationChip
-              key={u.inviteeEmail}
-              name={u.inviteeName}
-              email={u.inviteeEmail}
-              guardianCount={u.connectedGuardianCount ?? 0}
-              onRemove={() => invitation.removeUser(u.inviteeEmail)}
-            />
-          ))}
-        </ul>
+          {invitation.invitees.size === 0 && (
+            <span
+              className="text-gray-500"
+              aria-hidden="true"
+            >
+              {placeholder}
+            </span>
+          )}
+          <ul
+            role="list"
+            aria-label="초대 대상 목록"
+            className="flex min-h-12 flex-wrap gap-2"
+          >
+            {Array.from(invitation.invitees.values()).map((u) => (
+              <InvitationChip
+                key={u.inviteeEmail}
+                name={u.inviteeName}
+                email={u.inviteeEmail}
+                guardianCount={u.connectedGuardianCount ?? 0}
+                onRemove={() => invitation.removeUser(u.inviteeEmail)}
+              />
+            ))}
+          </ul>
+        </div>
       </Popover.Trigger>
       <Popover.Content>
         <InvitationSearchResult invitation={invitation} />

--- a/src/features/studyrooms/schemas/create.ts
+++ b/src/features/studyrooms/schemas/create.ts
@@ -41,10 +41,6 @@ export const CreateStudyRoomSchema = z.object({
       },
       { message: '학년 범위가 올바르지 않습니다.', path: ['grade'] }
     ),
-  emails: z.preprocess(
-    (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
-    z.string().email('올바른 이메일을 입력해주세요.').optional()
-  ),
 });
 
 export type StudyRoomFormValues = z.infer<typeof CreateStudyRoomSchema>;

--- a/src/features/studyrooms/schemas/invite.ts
+++ b/src/features/studyrooms/schemas/invite.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const InviteMemberSchema = z.object({
+  emails: z.preprocess(
+    (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+    z.string().email('올바른 이메일을 입력해주세요.').optional()
+  ),
+});
+
+export type InviteMemberSchema = z.infer<typeof InviteMemberSchema>;


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 린트 에러가 없습니다.
- [ ] 코드가 올바르게 포맷팅되었습니다.
- [ ] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
### invite-member 라우터 생성
<img width="1413" height="937" alt="image" src="https://github.com/user-attachments/assets/36f96c2f-579f-455f-9fd7-76d65e4bfbdb" />

- `/studyrooms/[id]/invite-member` 페이지 신규 생성  
- 스터디룸 생성 완료 후 초대 플로우로 자연스럽게 이동하도록 연결  
- 초대 필드, 유효성, 안내문, 버튼 등 기본 UI/UX 구성 완료 

### CreateStudyRoomFlow
- router.push → router.replace 변경 (히스토리 스택 최소화)
- 초대/대시보드 이동 로직을 handleSubmitCondition 으로 통합
- buildNextRoute() 유틸 함수 추가로 라우팅 관리
- RHF(useForm)의 handleSubmit 흐름을 유지하면서도 조건 기반 분기 적용
- dialogReducer 상태와 연동해 ConfirmDialog 제어 추가

### ConfirmDialog
<img width="768" height="463" alt="image" src="https://github.com/user-attachments/assets/15f36a16-9a75-40e4-bd07-bb582c168374" />

- 기존 단일 목적 다이얼로그를 공용 ConfirmDialog 형태로 1차 통합
- variant(ok / confirm / confirm-cancel / delete) 기반으로 재사용성 강화
- DialogAction 기반 dispatch 로직으로 상태 관리 통일
- studyroom(create) 전용으로 우선 적용 (다른 도메인은 추후 통합 예정)

### SEO 설정
- 홈(/) 페이지 메타데이터 추가
- robots.txt 자동 생성(Next.js MetadataRoute 기반)
- sitemap.xml 자동 생성(홈 경로 기준)
- changeFrequency, priority, lastModified 설정 추가
- SEO 설정은 현재 홈 페이지에만 적용됨
- 추후 스펙에 맞춰 확장 예정

## 🧐 관련 이슈
[[FE] 스터디룸 생성 화면 개발 v2](https://daechi-online.atlassian.net/jira/software/projects/BTS/boards/1?selectedIssue=BTS-228)

## TODO
- [x] 이 PR 내부에 메타데이터 설정(meta tags) 및 robots파일 설정을 추가한 후 병합 예정