### PR TITLE
BTS-255 / (학생화면) 수업노트 목록 탭 API 연결

### DIFF
--- a/src/app/(dashboard)/studyrooms/[id]/(study-note)/layout.tsx
+++ b/src/app/(dashboard)/studyrooms/[id]/(study-note)/layout.tsx
@@ -43,7 +43,7 @@ const StudyNoteLayout = ({ children }: LayoutProps) => {
             studyRoomId={studyRoomId}
             path={segment!}
           />
-          <div className="border-line-line1 flex flex-col gap-8 rounded-tr-[12px] rounded-b-[12px] border bg-white p-8">
+          <div className="border-line-line1 flex flex-col gap-9 rounded-tr-[12px] rounded-b-[12px] border bg-white p-8">
             <StudyNoteTabShell
               mode={role}
               path={segment!}

--- a/src/features/qna/components/detail/qna-list.tsx
+++ b/src/features/qna/components/detail/qna-list.tsx
@@ -22,7 +22,7 @@ export default function QuestionList({ studyRoomId, data }: Props) {
   };
 
   return (
-    <div>
+    <div className="gap-2">
       {data.length !== 0 ? (
         data.map((question) => {
           return (
@@ -77,11 +77,18 @@ export default function QuestionList({ studyRoomId, data }: Props) {
             </Link>
           );
         })
-      ) : (
+      ) : data.length === 0 ? (
         // TODO: 질문 없을때 예외 처리
         <div className="mt-2 w-full text-center">
           <span className="text-gray-scale-gray-20">
             작성된 질문이 없습니다
+          </span>
+        </div>
+      ) : (
+        // TODO: 로딩 UI 필요
+        <div className="mt-2 w-full text-center">
+          <span className="text-gray-scale-gray-20">
+            질문을 불러오고 있습니다
           </span>
         </div>
       )}

--- a/src/features/qna/components/detail/student-qna-tab.tsx
+++ b/src/features/qna/components/detail/student-qna-tab.tsx
@@ -7,6 +7,8 @@ import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
+import QuestionListWrapper from './qna-list-wrapper';
+
 type Props = {
   studyRoomId: number;
 };
@@ -56,6 +58,8 @@ export default function StudentQuestionSession({ studyRoomId }: Props) {
           </span>
         </Button>
       </form>
+
+      <QuestionListWrapper studyRoomId={studyRoomId} />
     </div>
   );
 }

--- a/src/features/studynotes/components/study-note-tab-shell.tsx
+++ b/src/features/studynotes/components/study-note-tab-shell.tsx
@@ -12,6 +12,9 @@ const StudyNoteTabShell = ({ mode, path }: Props) => {
   return (
     <>
       {path === 'note' && mode === 'ROLE_TEACHER' && <StudyNoteSearch />}
+      {path === 'note' && mode === 'ROLE_STUDENT' && (
+        <div>학생 수업노트 목록 조회 리스트 위치</div>
+      )}
       {/*{path === 'qna' && mode === 'ROLE_TEACHER' && (
         <TeacherQuestionSession studyRoomId={studyRoomId} />
       )}

--- a/src/features/studynotes/components/study-note-tab-shell.tsx
+++ b/src/features/studynotes/components/study-note-tab-shell.tsx
@@ -13,7 +13,15 @@ const StudyNoteTabShell = ({ mode, path }: Props) => {
     <>
       {path === 'note' && mode === 'ROLE_TEACHER' && <StudyNoteSearch />}
       {path === 'note' && mode === 'ROLE_STUDENT' && (
-        <div>학생 수업노트 목록 조회 리스트 위치</div>
+        <>
+          <p className="font-headline1-heading whitespace-pre-wrap">
+            {'지난 수업 내용을 확인해볼까요?'}
+          </p>
+          {/* <div>학생 수업노트 목록 조회 리스트 위치</div> */}
+          {/* <StudyNotes
+            selectedGroupId="all"
+          /> */}
+        </>
       )}
       {/*{path === 'qna' && mode === 'ROLE_TEACHER' && (
         <TeacherQuestionSession studyRoomId={studyRoomId} />

--- a/src/features/studynotes/services/api.ts
+++ b/src/features/studynotes/services/api.ts
@@ -5,6 +5,7 @@ import type {
 } from '@/features/studyrooms/components/studynotes/type';
 import { CommonResponse, PaginationMeta, apiClient } from '@/lib/api';
 
+// 선생님이 스터디노트 목록 조회
 export const getStudyNotes = async (args: {
   studyRoomId: number;
   pageable: StudyNoteGroupPageable;
@@ -25,6 +26,7 @@ export const getStudyNotes = async (args: {
   return response.data;
 };
 
+// 선생님이 스터디노트를 그룹별로 조회
 export const getStudyNotesByGroupId = async (params: {
   studyRoomId: number;
   teachingNoteGroupId: number;
@@ -33,6 +35,49 @@ export const getStudyNotesByGroupId = async (params: {
 }) => {
   const response = await apiClient.get(
     `/teacher/study-rooms/${params.studyRoomId}/teaching-note-groups/${params.teachingNoteGroupId}/teaching-notes`,
+    {
+      params: {
+        page: params.pageable.page,
+        size: params.pageable.size,
+        sortKey: params.pageable.sortKey,
+        // keyword: args.keyword,
+      },
+    }
+  );
+
+  return response.data;
+};
+
+// 학생이 스터디노트 목록 조회
+export const getStudentStudyNotes = async (args: {
+  studyRoomId: number;
+  pageable: StudyNoteGroupPageable;
+  // keyword: string;
+}) => {
+  const response = (
+    await apiClient.get<
+      CommonResponse<PaginationMeta & { content: StudyNote[] }>
+    >(`/student/study-rooms/${args.studyRoomId}/teaching-notes`, {
+      params: {
+        page: args.pageable.page,
+        size: args.pageable.size,
+        sortKey: args.pageable.sortKey,
+        // keyword: args.keyword,
+      },
+    })
+  ).data;
+  return response.data;
+};
+
+// 학생이 스터디노트를 그룹별로 조회
+export const getStudentStudyNotesByGroupId = async (params: {
+  studyRoomId: number;
+  teachingNoteGroupId: number;
+  pageable: StudyNoteGroupPageable;
+  // keyword: string;
+}) => {
+  const response = await apiClient.get(
+    `/student/study-rooms/${params.studyRoomId}/teaching-note-groups/${params.teachingNoteGroupId}/teaching-notes`,
     {
       params: {
         page: params.pageable.page,

--- a/src/features/studynotes/services/query-options.ts
+++ b/src/features/studynotes/services/query-options.ts
@@ -1,8 +1,11 @@
+import { Role } from '@/features/auth/type';
 import { getStudyNoteDetail } from '@/features/dashboard/studynote/detail/service/api';
 import { queryOptions } from '@tanstack/react-query';
 
 import type { StudyNoteGroupPageable } from '../../studyrooms/components/studynotes/type';
 import {
+  getStudentStudyNotes,
+  getStudentStudyNotesByGroupId,
   getStudyNoteMembers,
   getStudyNotes,
   getStudyNotesByGroupId,
@@ -16,25 +19,39 @@ export const StudyNoteQueryKey = {
   update: ['studynote', 'update'],
 };
 
-export const getStudyNotesOption = (args: {
-  studyRoomId: number;
-  pageable: StudyNoteGroupPageable;
-  // keyword: string;
-}) => {
+export const getStudyNotesOption = (
+  role: Role | undefined,
+  args: {
+    studyRoomId: number;
+    pageable: StudyNoteGroupPageable;
+    // keyword: string;
+  }
+) => {
   return queryOptions({
-    queryKey: [StudyNoteQueryKey.all, args],
-    queryFn: () => getStudyNotes(args),
+    queryKey: [StudyNoteQueryKey.all, args, role],
+    queryFn: async () => {
+      if (role === 'ROLE_TEACHER') return getStudyNotes(args);
+      if (role === 'ROLE_STUDENT') return getStudentStudyNotes(args);
+    },
+    enabled: !!role,
   });
 };
 
-export const getStudyNotesByGroupIdOption = (args: {
-  studyRoomId: number;
-  teachingNoteGroupId: number;
-  pageable: StudyNoteGroupPageable;
-}) => {
+export const getStudyNotesByGroupIdOption = (
+  role: Role | undefined,
+  args: {
+    studyRoomId: number;
+    teachingNoteGroupId: number;
+    pageable: StudyNoteGroupPageable;
+  }
+) => {
   return queryOptions({
-    queryKey: [StudyNoteQueryKey.byGroupId, args],
-    queryFn: () => getStudyNotesByGroupId(args),
+    queryKey: [StudyNoteQueryKey.byGroupId, args, role],
+    queryFn: async () => {
+      if (role === 'ROLE_TEACHER') return getStudyNotesByGroupId(args);
+      if (role === 'ROLE_STUDENT') return getStudentStudyNotesByGroupId(args);
+    },
+    enabled: !!role,
   });
 };
 

--- a/src/features/studynotes/services/query.ts
+++ b/src/features/studynotes/services/query.ts
@@ -1,3 +1,4 @@
+import { Role } from '@/features/auth/type';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type { StudyNoteGroupPageable } from '../../studyrooms/components/studynotes/type';
@@ -10,23 +11,29 @@ import {
   getStudyNotesOption,
 } from './query-options';
 
-export const useStudyNotesQuery = (args: {
-  studyRoomId: number;
-  pageable: StudyNoteGroupPageable;
-  // keyword: string;
-}) => {
-  return useQuery(getStudyNotesOption(args));
+export const useStudyNotesQuery = (
+  role: Role | undefined,
+  args: {
+    studyRoomId: number;
+    pageable: StudyNoteGroupPageable;
+    // keyword: string;
+  }
+) => {
+  return useQuery(getStudyNotesOption(role, args));
 };
 
-export const useStudyNotesByGroupIdQuery = (args: {
-  studyRoomId: number;
-  teachingNoteGroupId: number;
-  pageable: StudyNoteGroupPageable;
-  // keyword: string;
-  enabled?: boolean;
-}) => {
+export const useStudyNotesByGroupIdQuery = (
+  role: Role | undefined,
+  args: {
+    studyRoomId: number;
+    teachingNoteGroupId: number;
+    pageable: StudyNoteGroupPageable;
+    // keyword: string;
+    enabled?: boolean;
+  }
+) => {
   return useQuery({
-    ...getStudyNotesByGroupIdOption(args),
+    ...getStudyNotesByGroupIdOption(role, args),
     enabled: args.enabled !== false,
   });
 };

--- a/src/features/studyrooms/components/sidebar/groups/index.tsx
+++ b/src/features/studyrooms/components/sidebar/groups/index.tsx
@@ -2,6 +2,7 @@ import { useReducer } from 'react';
 
 import Image from 'next/image';
 
+import { Role } from '@/features/auth/type.js';
 import {
   dialogReducer,
   initialDialogState,
@@ -20,10 +21,12 @@ export const STUDYROOM_SIDEBAR_GROUPS_PAGEABLE = {
 };
 
 export const StudyroomGroups = ({
+  role,
   studyRoomId,
   selectedGroupId,
   handleSelectGroupId,
 }: {
+  role: Role | undefined;
   studyRoomId: number;
   selectedGroupId: number | 'all';
   handleSelectGroupId: (id: number | 'all') => void;
@@ -38,7 +41,7 @@ export const StudyroomGroups = ({
     isPending,
     isError,
   } = useInfiniteQuery({
-    ...getStudyNoteGroupInfiniteOption({
+    ...getStudyNoteGroupInfiniteOption(role, {
       studyRoomId: studyRoomId,
       pageable: STUDYROOM_SIDEBAR_GROUPS_PAGEABLE,
     }),
@@ -97,17 +100,19 @@ export const StudyroomGroups = ({
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-between">
           <p className="font-body1-heading">수업노트 그룹</p>
-          <div
-            className="hover:bg-gray-scale-gray-1 flex h-9 w-9 cursor-pointer items-center justify-center rounded-[8px]"
-            onClick={handleCreateGroupClick}
-          >
-            <Image
-              src="/studyroom/ic-plus.svg"
-              alt="plus"
-              width={16}
-              height={16}
-            />
-          </div>
+          {role === 'ROLE_TEACHER' && (
+            <div
+              className="hover:bg-gray-scale-gray-1 flex h-9 w-9 cursor-pointer items-center justify-center rounded-[8px]"
+              onClick={handleCreateGroupClick}
+            >
+              <Image
+                src="/studyroom/ic-plus.svg"
+                alt="plus"
+                width={16}
+                height={16}
+              />
+            </div>
+          )}
         </div>
 
         <div

--- a/src/features/studyrooms/components/sidebar/groups/llist-item.tsx
+++ b/src/features/studyrooms/components/sidebar/groups/llist-item.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 
 import { DropdownMenu } from '@/components/ui/dropdown-menu';
 import { DialogAction } from '@/features/studyrooms/hooks/useDialogReducer';
+import { useRole } from '@/hooks/use-role';
 import { cn } from '@/lib/utils';
 
 export const GroupListItem = ({
@@ -20,6 +21,7 @@ export const GroupListItem = ({
   dispatch: (action: DialogAction) => void;
 }) => {
   const [menuOpenId, setMenuOpenId] = useState<number | null>(null);
+  const { role } = useRole();
 
   const handleRenameGroup = () => {
     if (group.id === 'all') return;
@@ -70,7 +72,7 @@ export const GroupListItem = ({
         </p>
       </div>
 
-      {group.id !== 'all' && (
+      {group.id !== 'all' && role === 'ROLE_TEACHER' && (
         <DropdownMenu
           open={menuOpenId === group.id}
           onOpenChange={(open) => {

--- a/src/features/studyrooms/components/sidebar/index.tsx
+++ b/src/features/studyrooms/components/sidebar/index.tsx
@@ -14,6 +14,7 @@ import {
   dialogReducer,
   initialDialogState,
 } from '@/features/studyrooms/hooks/useDialogReducer';
+import { useRole } from '@/hooks/use-role';
 
 import { StudyroomSidebarHeader } from './header';
 import { useDeleteStudyRoom } from './services/query';
@@ -28,6 +29,7 @@ export const StudyroomSidebar = ({ studyRoomId }: { studyRoomId: number }) => {
   const [roomName, setRoomName] = useState('');
   const [deleteNoticeMsg, setDeleteNoticeMsg] =
     useState('수업노트 그룹이 삭제되었습니다.');
+  const { role } = useRole();
 
   const { mutate: deleteStudyRoom } = useDeleteStudyRoom();
 
@@ -104,6 +106,7 @@ export const StudyroomSidebar = ({ studyRoomId }: { studyRoomId: number }) => {
         {/* 수업노트 탭에서만 보이는 컴포넌트 */}
         {segment === 'note' && (
           <StudyroomGroups
+            role={role}
             studyRoomId={studyRoomId}
             selectedGroupId={selectedGroupId}
             handleSelectGroupId={handleSelectGroupId}

--- a/src/features/studyrooms/components/studynotes/dialog/group-move-dialog.tsx
+++ b/src/features/studyrooms/components/studynotes/dialog/group-move-dialog.tsx
@@ -12,6 +12,7 @@ import { Select } from '@/features/studyrooms/components/common/select';
 import { DialogAction } from '@/features/studyrooms/hooks/useDialogReducer';
 import { getStudyNoteGroupInfiniteOption } from '@/features/studyrooms/services/query-options';
 import { useInfiniteScroll } from '@/hooks/use-infinite-scroll';
+import { useRole } from '@/hooks/use-role';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 import type { StudyNoteGroupPageable } from '../type';
@@ -38,6 +39,7 @@ export const GroupMoveDialog = ({
   keyword: string;
 }) => {
   const [selectedGroup, setSelectedGroup] = useState<string | null>('all');
+  const { role } = useRole();
 
   const {
     data: studyNoteGroups,
@@ -47,7 +49,7 @@ export const GroupMoveDialog = ({
     isPending,
     isError,
   } = useInfiniteQuery({
-    ...getStudyNoteGroupInfiniteOption({
+    ...getStudyNoteGroupInfiniteOption(role, {
       studyRoomId: studyRoomId,
       pageable: GROUP_MOVE_DIALOG_PAGEABLE,
     }),

--- a/src/features/studyrooms/components/studynotes/index.tsx
+++ b/src/features/studyrooms/components/studynotes/index.tsx
@@ -8,6 +8,7 @@ import {
   useStudyNotesByGroupIdQuery,
   useStudyNotesQuery,
 } from '@/features/studynotes/services/query';
+import { useRole } from '@/hooks/use-role';
 
 import { StudyRoomDetailLayout } from '../common/layout';
 import { StudyNotesList } from './list';
@@ -27,6 +28,7 @@ export const StudyNotes = ({
   const [limit, setLimit] = useState<StudyNoteLimit>(20);
   const [currentPage, setCurrentPage] = useState(0);
 
+  const { role } = useRole();
   const { id } = useParams();
   const studyRoomId = Number(id);
 
@@ -37,14 +39,14 @@ export const StudyNotes = ({
   };
 
   // TODO: 수업노트 조회 API keyword search 연결
-  const { data } = useStudyNotesQuery({
+  const { data } = useStudyNotesQuery(role, {
     studyRoomId: studyRoomId,
     pageable: pageable,
     // keyword: search,
   });
 
   // TODO: 수업노트 그룹으로 수업노트 조회 API keyword search 연결
-  const { data: studyNotesByGroupId } = useStudyNotesByGroupIdQuery({
+  const { data: studyNotesByGroupId } = useStudyNotesByGroupIdQuery(role, {
     studyRoomId: studyRoomId,
     teachingNoteGroupId: Number(selectedGroupId),
     pageable: pageable,

--- a/src/features/studyrooms/services/api.ts
+++ b/src/features/studyrooms/services/api.ts
@@ -22,7 +22,7 @@ export const getStudentStudyRooms = async () => {
   return response.data;
 };
 
-// 수업노트 그룹 조회
+// (선생님) 수업노트 그룹 조회
 export const getStudyNoteGroup = async (args: {
   studyRoomId: number;
   pageable: Pageable;
@@ -31,6 +31,28 @@ export const getStudyNoteGroup = async (args: {
     await apiClient.get<
       CommonResponse<PaginationMeta & { content: StudyNoteGroup[] }>
     >(`/teacher/study-rooms/${args.studyRoomId}/teaching-note-groups`, {
+      params: {
+        page: args.pageable.page,
+        size: args.pageable.size,
+        sort: args.pageable.sort,
+      },
+      paramsSerializer: {
+        indexes: null,
+      },
+    })
+  ).data;
+  return response.data;
+};
+
+// (학생) 수업노트 그룹 조회
+export const getStudentStudyNoteGroup = async (args: {
+  studyRoomId: number;
+  pageable: Pageable;
+}) => {
+  const response = (
+    await apiClient.get<
+      CommonResponse<PaginationMeta & { content: StudyNoteGroup[] }>
+    >(`/student/study-rooms/${args.studyRoomId}/teaching-note-groups`, {
       params: {
         page: args.pageable.page,
         size: args.pageable.size,

--- a/src/features/studyrooms/services/query-options.ts
+++ b/src/features/studyrooms/services/query-options.ts
@@ -43,7 +43,6 @@ export const getStudyNoteGroupInfiniteOption = (
       };
       if (role === 'ROLE_TEACHER') return getStudyNoteGroup(req);
       if (role === 'ROLE_STUDENT') return getStudentStudyNoteGroup(req);
-      // enabled가 false면 실행되지 않지만 방어
       return Promise.reject(new Error('role not ready'));
     },
     initialPageParam: 0,


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
<!-- 
- 변경된 내용에 대해 간략하게 설명해주세요.
- 예: 사용자 로그인 기능 추가
- 예: API 응답 구조 변경 
-->
  
**BREAKING CHANGES**
* 학생의 스터디노트 화면 기능을 추가했습니다

추신
빠른 수정을 위해 주석 정리가 잘 안되어있을 수 있습니다. 이 점 추후에 코드 리뷰 시간 가지게 된다면 정리하겠습니다

## 🧐 관련 이슈
<!--
- 관련된 이슈 번호를 적어주세요. (ex. `Closes #123`, `Fixes #456`) 
-->

현재 ROLE을 서버단에서 구분할 수 없는 상태여서 기획대로 디자인을 학생/선생님을 나눌 수 없는 상황입니다.

[[StudyNote / QnA] 학생/선생님 화면 디자인 불일치](https://daechi-online.atlassian.net/browse/QA-2?atlOrigin=eyJpIjoiZTUyZmJjOWU2NDU4NDNlY2IxMjNmZWZkNjc2YzE1OTgiLCJwIjoiaiJ9)

useSession 혹은 관련된 백엔드 API 완성하는대로 리팩토링이 필요합니다.


**추가 버그 발견**
* 작업 중 수업노트그룹 선택시 관련 수업노트가 필터링 되지 않는 버그 발견
* 10/18 모임 당시 해당 내용 작동했던 점 확인
* 예상 오류: [PR#79 BTS-257](https://github.com/idealstudy/mvp-front/pull/79) url/라우트로 분리하면서 수업노트 그룹 선택하는 기능이 분리된것으로 추정
@JangHwanPark 시간 날때 확인 부탁드립니다.

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->

학생화면 중 스터디노트 페이지 API 연동 및 디자인
<img width="1106" height="919" alt="image" src="https://github.com/user-attachments/assets/34c49c26-a4e3-4e1a-a27b-2b4f3af19b38" />

[보너스]
이전의 PR에서 학생의 질문목록 컴포넌트가 사라져 복구했습니다. 
이슈에서 언급한것처럼 현재 디자인은 기획과 차이가 있습니다
<img width="1121" height="783" alt="image" src="https://github.com/user-attachments/assets/94aeefe2-fcc1-4126-9e9a-3623709b9cb5" />


## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
