### PR TITLE
BTS-299 / hotfix - 세션 로딩 중복 요청 및 로그인 후 튕김 현상 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ yarn-error.log*
 next-env.d.ts
 
 *storybook.log
+
+certificates

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,9 @@
+app.dev.the-edu.site {
+    tls app.dev.the-edu.site.pem app.dev.the-edu.site-key.pem
+
+    @api path /api/*
+    reverse_proxy @api https://dev.the-edu.site {
+    header_up Host {upstream_hostport}
+}
+    reverse_proxy localhost:3000
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: ['app.dev.the-edu.site', '*.dev.the-edu.site'],
   turbopack: {
     rules: {
       '*.svg': {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
+    "https": "next dev -H app.dev.the-edu.site -p 3000 --experimental-https",
     "build": "next build",
     "start": "next start",
     "lint": "next lint --max-warnings 0",

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,4 +1,5 @@
 import { Sidebar } from '@/components/layout/sidebar';
+import { SessionProvider } from '@/providers/session-provider';
 
 export default function DashboardLayout({
   children,
@@ -6,9 +7,11 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="desktop:pl-sidebar-width flex flex-col bg-[#F9F9F9]">
-      <Sidebar />
-      <div className="px-grid-margin w-full">{children}</div>
-    </div>
+    <SessionProvider>
+      <div className="desktop:pl-sidebar-width flex flex-col bg-[#F9F9F9]">
+        <Sidebar />
+        <div className="px-grid-margin w-full">{children}</div>
+      </div>
+    </SessionProvider>
   );
 }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -7,19 +7,20 @@ import Link from 'next/link';
 
 import { ROUTE } from '@/constants/route';
 import { useAuth } from '@/features/auth/hooks/use-auth';
-import { useSession } from '@/features/auth/hooks/use-session';
+import { useSessionStore } from '@/store/session-store';
 
 // import { useLogoutMutation } from '@/features/auth/services/query';
 
 import { DropdownMenu } from '../ui/dropdown-menu';
 
 export const Header = () => {
-  const { data: session } = useSession();
+  const session = useSessionStore((s) => s.user);
+
   // const router = useRouter();
   // const { mutate: logout } = useLogoutMutation();
   const { logout } = useAuth();
   const handleLogout = () => {
-    logout();
+    void logout();
     // TODO: 세션 유효한지 확인하는 API / Logout API 부재로
     // window.location 사용 => 추후에 router.replace로 변경
     window.location.replace(ROUTE.HOME);
@@ -27,6 +28,10 @@ export const Header = () => {
   };
 
   const roleMetaMap = {
+    ROLE_ADMIN: {
+      label: '관리자',
+      className: 'border-white text-white',
+    },
     ROLE_STUDENT: {
       label: '학생',
       className: 'border-white text-white',
@@ -49,9 +54,7 @@ export const Header = () => {
       <div className="mx-auto flex w-full items-center justify-between">
         <div className="flex items-center gap-2">
           <Link
-            href={
-              session?.auth === undefined ? ROUTE.HOME : ROUTE.DASHBOARD.HOME
-            }
+            href={session === undefined ? ROUTE.HOME : ROUTE.DASHBOARD.HOME}
           >
             <Image
               src={'/logo.svg'}
@@ -67,7 +70,7 @@ export const Header = () => {
             width={44}
             height={20}
           />
-          {session?.auth && (
+          {session && (
             <>
               {/* <Link
                 href={ROUTE.DASHBOARD.HOME}
@@ -87,7 +90,7 @@ export const Header = () => {
             </>
           )}
         </div>
-        {session?.auth && (
+        {session && (
           <div className="flex items-center">
             <Image
               src={'/img_header_bell.svg'}
@@ -118,7 +121,7 @@ export const Header = () => {
               {session.nickname}
             </p>
             <div className="desktop:flex hidden items-center gap-2 rounded-[40px] border px-2 py-[2px] text-[12px] font-[400px] text-[#ffffff]">
-              {roleMetaMap[session.auth].label}
+              {roleMetaMap[session.role].label}
             </div>
             <Image
               src={'/ic_hamburger.svg'}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -7,14 +7,14 @@ import Link from 'next/link';
 
 import { ROUTE } from '@/constants/route';
 import { useAuth } from '@/features/auth/hooks/use-auth';
-import { useSessionStore } from '@/store/session-store';
+import { useAuthStore } from '@/store/session-store';
 
 // import { useLogoutMutation } from '@/features/auth/services/query';
 
 import { DropdownMenu } from '../ui/dropdown-menu';
 
 export const Header = () => {
-  const session = useSessionStore((s) => s.user);
+  const session = useAuthStore((s) => s.user);
 
   // const router = useRouter();
   // const { mutate: logout } = useLogoutMutation();
@@ -53,9 +53,7 @@ export const Header = () => {
     <header className="h-header-height fixed top-0 right-0 left-0 z-10 flex items-center border-b border-gray-200 bg-[#1A1A1A] px-8">
       <div className="mx-auto flex w-full items-center justify-between">
         <div className="flex items-center gap-2">
-          <Link
-            href={session === undefined ? ROUTE.HOME : ROUTE.DASHBOARD.HOME}
-          >
+          <Link href={session === null ? ROUTE.HOME : ROUTE.DASHBOARD.HOME}>
             <Image
               src={'/logo.svg'}
               alt="THE EDU 로고"
@@ -120,9 +118,11 @@ export const Header = () => {
             <p className="desktop:flex mr-2 hidden items-center gap-2 text-[14px] font-[600] text-white">
               {session.nickname}
             </p>
-            <div className="desktop:flex hidden items-center gap-2 rounded-[40px] border px-2 py-[2px] text-[12px] font-[400px] text-[#ffffff]">
-              {roleMetaMap[session.role].label}
-            </div>
+            {session?.role && (
+              <div className="desktop:flex hidden items-center gap-2 rounded-[40px] border px-2 py-[2px] text-[12px] font-[400px] text-[#ffffff]">
+                {roleMetaMap[session.role]?.label}
+              </div>
+            )}
             <Image
               src={'/ic_hamburger.svg'}
               alt="햄버거 메뉴 아이콘"

--- a/src/constants/query-key.ts
+++ b/src/constants/query-key.ts
@@ -1,3 +1,3 @@
 export const queryKey = {
-  session: ['session'],
+  session: ['member', 'info'],
 } as const;

--- a/src/features/auth/hooks/use-auth.ts
+++ b/src/features/auth/hooks/use-auth.ts
@@ -5,29 +5,25 @@ import { useQueryClient } from '@tanstack/react-query';
 
 export const useAuth = () => {
   const queryClient = useQueryClient();
-  const { user, setUser, isAuthenticated } = useAuthStore();
+  const { user, setUser, clearUser } = useAuthStore();
 
   const fetchSession = async () => {
-    // 쿠키 기반 세션 정보 가져오기
-    const me = await authService.getSession(); // { id, email, role }
-    // (선택) 여기서 zod로 검증
-    setUser(me);
-    // React Query 캐시에도 넣어두면 재요청 줄임
-    queryClient.setQueryData(['me'], me);
-    return me;
+    const member = await authService.getSession();
+    setUser(member);
+    queryClient.setQueryData(memberKeys.info(), member);
+    return member;
   };
 
   const login = async (form?: { email: string; password: string }) => {
-    if (form) await authService.login(form); // 쿠키 세팅 (응답 바디 없음)
-
+    if (form) await authService.login(form);
     return fetchSession();
   };
 
   const logout = async () => {
     // NOTE: 로그아웃 시 세션 캐시 초기화 및 무효화
-    queryClient.setQueryData(memberKeys.info(), null);
-    await queryClient.invalidateQueries({ queryKey: memberKeys.info() });
+    clearUser();
+    queryClient.removeQueries({ queryKey: memberKeys.info(), exact: true });
   };
 
-  return { user, isAuthenticated, login, logout, fetchSession };
+  return { user, login, logout, fetchSession };
 };

--- a/src/features/auth/hooks/use-auth.ts
+++ b/src/features/auth/hooks/use-auth.ts
@@ -1,5 +1,4 @@
 import { queryKey } from '@/constants/query-key';
-import { sessionQueryOption } from '@/features/auth/services/query-options';
 import { useQueryClient } from '@tanstack/react-query';
 
 export const useAuth = () => {
@@ -10,9 +9,6 @@ export const useAuth = () => {
     await queryClient.invalidateQueries({
       queryKey: queryKey.session,
     });
-
-    // NOTE: 최신 세션 정보 강제 로드(ex.사용자 프로필 동기화)
-    await queryClient.ensureQueryData(sessionQueryOption);
   };
 
   const logout = async () => {

--- a/src/features/auth/hooks/use-auth.ts
+++ b/src/features/auth/hooks/use-auth.ts
@@ -1,24 +1,33 @@
-import { queryKey } from '@/constants/query-key';
+import { authService } from '@/features/auth/services/api';
+import { memberKeys } from '@/features/member/api/keys';
+import { useAuthStore } from '@/store/session-store';
 import { useQueryClient } from '@tanstack/react-query';
 
 export const useAuth = () => {
   const queryClient = useQueryClient();
+  const { user, setUser, isAuthenticated } = useAuthStore();
 
-  const login = async () => {
-    // NOTE: 로그인 성공 후 세션 캐시를 갱신하기 위해 기존 데이터 무효화
-    await queryClient.invalidateQueries({
-      queryKey: queryKey.session,
-    });
+  const fetchSession = async () => {
+    // 쿠키 기반 세션 정보 가져오기
+    const me = await authService.getSession(); // { id, email, role }
+    // (선택) 여기서 zod로 검증
+    setUser(me);
+    // React Query 캐시에도 넣어두면 재요청 줄임
+    queryClient.setQueryData(['me'], me);
+    return me;
+  };
+
+  const login = async (form?: { email: string; password: string }) => {
+    if (form) await authService.login(form); // 쿠키 세팅 (응답 바디 없음)
+
+    return fetchSession();
   };
 
   const logout = async () => {
     // NOTE: 로그아웃 시 세션 캐시 초기화 및 무효화
-    queryClient.setQueryData(queryKey.session, null);
-    await queryClient.invalidateQueries({ queryKey: queryKey.session });
+    queryClient.setQueryData(memberKeys.info(), null);
+    await queryClient.invalidateQueries({ queryKey: memberKeys.info() });
   };
 
-  return {
-    login,
-    logout,
-  };
+  return { user, isAuthenticated, login, logout, fetchSession };
 };

--- a/src/features/auth/hooks/use-me.ts
+++ b/src/features/auth/hooks/use-me.ts
@@ -1,0 +1,17 @@
+import { authService } from '@/features/auth/services/api';
+import { useAuthStore } from '@/store/session-store';
+import { useQuery } from '@tanstack/react-query';
+
+export function useMe(options?: { enabled?: boolean }) {
+  const setUser = useAuthStore((s) => s.setUser);
+  return useQuery({
+    queryKey: ['me'],
+    queryFn: async () => {
+      const me = await authService.getSession();
+      setUser(me);
+      return me;
+    },
+    staleTime: 5 * 60 * 1000,
+    enabled: options?.enabled ?? false,
+  });
+}

--- a/src/features/auth/hooks/use-me.ts
+++ b/src/features/auth/hooks/use-me.ts
@@ -1,11 +1,12 @@
 import { authService } from '@/features/auth/services/api';
 import { useAuthStore } from '@/store/session-store';
 import { useQuery } from '@tanstack/react-query';
+import { memberKeys } from '@/features/member/api/keys';
 
 export function useMe(options?: { enabled?: boolean }) {
   const setUser = useAuthStore((s) => s.setUser);
   return useQuery({
-    queryKey: ['me'],
+    queryKey: memberKeys.info(),
     queryFn: async () => {
       const me = await authService.getSession();
       setUser(me);

--- a/src/features/auth/services/api.ts
+++ b/src/features/auth/services/api.ts
@@ -14,7 +14,7 @@ export const authService = {
     return authApi.post('/auth/logout');
   },
   getSession: async () => {
-    return authApi.get('/');
+    return authApi.get('/member/info');
   },
   checkEmailDuplicate: async (body: CheckEmailDuplicateBody) => {
     return publicApi.post('/public/email-verifications/check-duplicate', body);

--- a/src/features/auth/services/api.ts
+++ b/src/features/auth/services/api.ts
@@ -4,6 +4,7 @@ import {
   SignUpBody,
   VerifyCodeBody,
 } from '@/features/auth/type';
+import type { Member } from '@/features/member/model/types';
 import { authApi, publicApi } from '@/lib/http/api';
 
 export const authService = {
@@ -14,7 +15,7 @@ export const authService = {
     return authApi.post('/auth/logout');
   },
   getSession: async () => {
-    return authApi.get('/member/info');
+    return authApi.get<Member>('/members/info');
   },
   checkEmailDuplicate: async (body: CheckEmailDuplicateBody) => {
     return publicApi.post('/public/email-verifications/check-duplicate', body);

--- a/src/features/auth/services/query-options.ts
+++ b/src/features/auth/services/query-options.ts
@@ -1,5 +1,6 @@
 import { queryKey } from '@/constants/query-key';
-import { fetchMemberInfo } from '@/features/member/api/requests';
+import { authService } from '@/features/auth/services/api';
+// import { fetchMemberInfo } from '@/features/member/api/requests';
 import { queryOptions } from '@tanstack/react-query';
 
 /**
@@ -12,6 +13,6 @@ import { queryOptions } from '@tanstack/react-query';
  */
 export const sessionQueryOption = queryOptions({
   queryKey: queryKey.session,
-  queryFn: fetchMemberInfo,
+  queryFn: authService.getSession,
   staleTime: 5 * 60 * 1000,
 });

--- a/src/features/auth/services/query-options.ts
+++ b/src/features/auth/services/query-options.ts
@@ -1,7 +1,6 @@
 import { queryKey } from '@/constants/query-key';
+import { fetchMemberInfo } from '@/features/member/api/requests';
 import { queryOptions } from '@tanstack/react-query';
-
-import { getLocalSession } from './session';
 
 /**
  * [TODO 임시 버전]
@@ -13,6 +12,6 @@ import { getLocalSession } from './session';
  */
 export const sessionQueryOption = queryOptions({
   queryKey: queryKey.session,
-  queryFn: getLocalSession,
-  retry: false,
+  queryFn: fetchMemberInfo,
+  staleTime: 5 * 60 * 1000,
 });

--- a/src/features/auth/services/query.ts
+++ b/src/features/auth/services/query.ts
@@ -16,7 +16,6 @@ export const useLoginMutation = () => {
       await new Promise((resolve) => setTimeout(resolve, 100));
       await auth.login();
       router.replace(ROUTE.DASHBOARD.HOME);
-      // router.replace("/dashboard");
     },
   });
 };

--- a/src/features/auth/services/query.ts
+++ b/src/features/auth/services/query.ts
@@ -13,8 +13,10 @@ export const useLoginMutation = () => {
   return useMutation({
     mutationFn: authService.login,
     onSuccess: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
       await auth.login();
       router.replace(ROUTE.DASHBOARD.HOME);
+      // router.replace("/dashboard");
     },
   });
 };

--- a/src/features/auth/type.ts
+++ b/src/features/auth/type.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod';
 
-export const ROLES = ['ROLE_STUDENT', 'ROLE_TEACHER', 'ROLE_PARENT'] as const;
+export const ROLES = [
+  'ROLE_ADMIN',
+  'ROLE_PARENT',
+  'ROLE_TEACHER',
+  'ROLE_STUDENT',
+] as const;
 export type Role = (typeof ROLES)[number];
 export const Role = z.enum(ROLES);
 

--- a/src/features/dashboard/connect/components/empty-connection-dialog.tsx
+++ b/src/features/dashboard/connect/components/empty-connection-dialog.tsx
@@ -29,7 +29,7 @@ export const EmptyConnectionDialog = () => {
   const hasConnections =
     Array.isArray(data?.connectionList) && data.connectionList.length > 0;
 
-  const userRole = session.data?.auth;
+  const userRole = session.data?.role;
 
   const [isOpen, setIsOpen] = useState(false);
 

--- a/src/features/member/api/keys.ts
+++ b/src/features/member/api/keys.ts
@@ -1,0 +1,4 @@
+export const memberKeys = {
+  all: ['member'] as const,
+  info: () => [...memberKeys.all, 'info'] as const,
+};

--- a/src/features/member/api/options.ts
+++ b/src/features/member/api/options.ts
@@ -1,0 +1,15 @@
+import { MEMBER_QUERY_STALE_TIME } from '@/features/member/model/constants';
+import { queryOptions } from '@tanstack/react-query';
+
+import { memberKeys } from './keys';
+import { fetchMemberInfo } from './requests';
+
+export const getMemberInfoOptions = () =>
+  queryOptions({
+    queryKey: memberKeys.info(),
+    queryFn: fetchMemberInfo,
+    staleTime: MEMBER_QUERY_STALE_TIME,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    retry: false,
+  });

--- a/src/features/member/api/requests.ts
+++ b/src/features/member/api/requests.ts
@@ -1,0 +1,18 @@
+import { authApi } from '@/lib/http/api';
+import type { z } from 'zod';
+
+import {
+  MemberAnyResponseSchema,
+  MemberEnvelopeSchema,
+  MemberSchema,
+} from '../model/schema';
+
+type MemberEnvelope = z.infer<typeof MemberEnvelopeSchema>;
+type Member = z.infer<typeof MemberSchema>;
+
+export const fetchMemberInfo = async (): Promise<Member> => {
+  const response = await authApi.get<MemberEnvelope | Member>('/members/info');
+  const env = MemberAnyResponseSchema.safeParse(response);
+  const payload = env.success ? env.data : MemberSchema.parse(response);
+  return MemberSchema.parse(payload);
+};

--- a/src/features/member/hooks/use-queries.ts
+++ b/src/features/member/hooks/use-queries.ts
@@ -1,0 +1,12 @@
+import { memberKeys } from '@/features/member/api/keys';
+import { getMemberInfoOptions } from '@/features/member/api/options';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+export const useMemberInfo = (enabled?: boolean) => {
+  const queryClient = useQueryClient();
+  return useQuery({
+    ...getMemberInfoOptions(),
+    enabled: enabled ?? true,
+    initialData: () => queryClient.getQueryData(memberKeys.info()),
+  });
+};

--- a/src/features/member/model/constants.ts
+++ b/src/features/member/model/constants.ts
@@ -1,0 +1,2 @@
+// 5분
+export const MEMBER_QUERY_STALE_TIME = 5 * 60 * 1000;

--- a/src/features/member/model/schema.ts
+++ b/src/features/member/model/schema.ts
@@ -1,22 +1,28 @@
 import { z } from 'zod';
 
-export const MemberInfoSchema = z.object({
-  status: z.number(),
-  message: z.string(),
-  data: z.object({
-    id: z.number(),
-    email: z.string().email(),
-    password: z.string(),
-    name: z.string(),
-    nickname: z.string(),
-    phoneNumber: z.string(),
-    birthDate: z.string().date(),
-    acceptRequiredTerm: z.boolean(),
-    acceptOptionalTerm: z.boolean(),
-    role: z.enum(['ROLE_ADMIN', 'ROLE_USER', 'ROLE_TEACHER', 'ROLE_STUDENT']),
-    regDate: z.string(),
-    modDate: z.string(),
-  }),
+export const MemberSchema = z.object({
+  id: z.number().int().nonnegative(),
+  email: z.string().email(),
+  name: z.string().optional(),
+  nickname: z.string().optional(),
+  phoneNumber: z.string().optional(),
+  // ISO: YYYY-MM-DD
+  birthDate: z.string().optional(),
+  acceptRequiredTerm: z.boolean().optional(),
+  acceptOptionalTerm: z.boolean().optional(),
+  role: z.enum(['ROLE_ADMIN', 'ROLE_PARENT', 'ROLE_TEACHER', 'ROLE_STUDENT']),
+  // ISO date-time
+  regDate: z.string().optional(),
+  modDate: z.string().optional(),
 });
 
-export type MemberInfo = z.infer<typeof MemberInfoSchema>;
+export const MemberEnvelopeSchema = z.object({
+  status: z.number(),
+  message: z.string().optional(),
+  data: MemberSchema,
+});
+
+export const MemberAnyResponseSchema = z.union([
+  MemberSchema,
+  MemberEnvelopeSchema,
+]);

--- a/src/features/member/model/schema.ts
+++ b/src/features/member/model/schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const MemberInfoSchema = z.object({
+  status: z.number(),
+  message: z.string(),
+  data: z.object({
+    id: z.number(),
+    email: z.string().email(),
+    password: z.string(),
+    name: z.string(),
+    nickname: z.string(),
+    phoneNumber: z.string(),
+    birthDate: z.string().date(),
+    acceptRequiredTerm: z.boolean(),
+    acceptOptionalTerm: z.boolean(),
+    role: z.enum(['ROLE_ADMIN', 'ROLE_USER', 'ROLE_TEACHER', 'ROLE_STUDENT']),
+    regDate: z.string(),
+    modDate: z.string(),
+  }),
+});
+
+export type MemberInfo = z.infer<typeof MemberInfoSchema>;

--- a/src/features/member/model/types.ts
+++ b/src/features/member/model/types.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+import { MemberSchema } from './schema';
+
+export type Member = z.infer<typeof MemberSchema>;
+
+export type SessionLike = {
+  auth: Member['role'];
+  memberId: Member['id'];
+  email: Member['email'];
+  name?: Member['name'];
+  nickname?: Member['nickname'];
+};
+
+export const toSessionLike = (m: Member): SessionLike => ({
+  auth: m.role,
+  memberId: m.id,
+  email: m.email,
+  name: m.name,
+  nickname: m.nickname ?? m.name,
+});

--- a/src/hooks/use-role.ts
+++ b/src/hooks/use-role.ts
@@ -1,6 +1,7 @@
+// import { sessionQueryOption } from '@/features/auth/services/query-options';
 import { queryKey } from '@/constants/query-key';
-import { getLocalSession } from '@/features/auth/services/session';
-import type { Session } from '@/features/auth/type';
+import { fetchMemberInfo } from '@/features/member/api/requests';
+import { Member } from '@/features/member/model/types';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 /**
@@ -16,12 +17,15 @@ export const useRole = () => {
 
   const { data, isLoading } = useQuery({
     queryKey: queryKey.session,
-    queryFn: getLocalSession,
-    initialData: () => qc.getQueryData<Session>(queryKey.session),
-    staleTime: 0,
-    refetchOnMount: 'always',
+    queryFn: fetchMemberInfo,
+    initialData: () => qc.getQueryData<Member>(queryKey.session),
+    refetchOnMount: false,
     refetchOnWindowFocus: false,
+    retry: false,
   });
 
-  return { role: data?.auth, isLoading };
+  return { role: data?.role, isLoading };
+  /*const { data, isLoading } = useQuery(sessionQueryOption);
+
+  return { role: data?.auth, isLoading };*/
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  // 개발용
+  if (process.env.NODE_ENV !== 'production') return NextResponse.next();
+
+  const { pathname } = req.nextUrl;
+  const auth = req.cookies.get('Authorization');
+
+  if (pathname.startsWith('/login')) return NextResponse.next();
+
+  if (pathname.startsWith('/dashboard') && !auth) {
+    const url = req.nextUrl.clone();
+    url.pathname = '/login';
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
+
+// 필요 시 특정 경로만 매칭
+// '/((?!_next/static|_next/image|favicon.ico|api).*)', // 전역 가드 예시
+export const config = {
+  matcher: ['/dashboard/:path*'],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,11 +5,11 @@ export function middleware(req: NextRequest) {
   if (process.env.NODE_ENV !== 'production') return NextResponse.next();
 
   const { pathname } = req.nextUrl;
-  const auth = req.cookies.get('Authorization');
+  const hasAuth = req.cookies.get('Authorization');
 
   if (pathname.startsWith('/login')) return NextResponse.next();
 
-  if (pathname.startsWith('/dashboard') && !auth) {
+  if (pathname.startsWith('/dashboard') && !hasAuth) {
     const url = req.nextUrl.clone();
     url.pathname = '/login';
     return NextResponse.redirect(url);

--- a/src/providers/session-provider.tsx
+++ b/src/providers/session-provider.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { ReactNode, useEffect } from 'react';
+
+import { useMemberInfo } from '@/features/member/hooks/use-queries';
+import { useSessionStore } from '@/store/session-store';
+
+export const SessionProvider = ({ children }: { children: ReactNode }) => {
+  const { data: member, isLoading } = useMemberInfo();
+  const { setUser, clearUser } = useSessionStore();
+
+  useEffect(() => {
+    if (member) setUser(member);
+    else clearUser();
+  }, [member, setUser, clearUser]);
+
+  if (isLoading)
+    return (
+      <div className="flex h-screen items-center justify-center text-white">
+        세션을 불러오는 중입니다...
+      </div>
+    );
+
+  if (!member) {
+    window.location.replace('/login');
+    return null;
+  }
+
+  return <>{children}</>;
+};

--- a/src/providers/session-provider.tsx
+++ b/src/providers/session-provider.tsx
@@ -3,11 +3,11 @@
 import { ReactNode, useEffect } from 'react';
 
 import { useMemberInfo } from '@/features/member/hooks/use-queries';
-import { useSessionStore } from '@/store/session-store';
+import { useAuthStore } from '@/store/session-store';
 
 export const SessionProvider = ({ children }: { children: ReactNode }) => {
   const { data: member, isLoading } = useMemberInfo();
-  const { setUser, clearUser } = useSessionStore();
+  const { setUser, clearUser } = useAuthStore();
 
   useEffect(() => {
     if (member) setUser(member);

--- a/src/store/session-store.ts
+++ b/src/store/session-store.ts
@@ -1,0 +1,14 @@
+import type { Member } from '@/features/member/model/types';
+import { create } from 'zustand';
+
+interface SessionState {
+  user: Member | null;
+  setUser: (user: Member | null) => void;
+  clearUser: () => void;
+}
+
+export const useSessionStore = create<SessionState>((set) => ({
+  user: null,
+  setUser: (user) => set({ user }),
+  clearUser: () => set({ user: null }),
+}));

--- a/src/store/session-store.ts
+++ b/src/store/session-store.ts
@@ -1,14 +1,16 @@
 import type { Member } from '@/features/member/model/types';
 import { create } from 'zustand';
 
-interface SessionState {
+interface AuthState {
   user: Member | null;
   setUser: (user: Member | null) => void;
   clearUser: () => void;
+  isAuthenticated: boolean;
 }
 
-export const useSessionStore = create<SessionState>((set) => ({
+export const useAuthStore = create<AuthState>((set) => ({
   user: null,
   setUser: (user) => set({ user }),
   clearUser: () => set({ user: null }),
+  isAuthenticated: false,
 }));

--- a/src/store/session-store.ts
+++ b/src/store/session-store.ts
@@ -5,12 +5,10 @@ interface AuthState {
   user: Member | null;
   setUser: (user: Member | null) => void;
   clearUser: () => void;
-  isAuthenticated: boolean;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   user: null,
   setUser: (user) => set({ user }),
   clearUser: () => set({ user: null }),
-  isAuthenticated: false,
 }));


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
### 세션 로딩 시 네비게이션 초기화 및 튕김 현상 수정
- SessionProvider 로직 개선: 세션 데이터를 불러오는 중 발생하던 중복 요청을 제거했습니다.
- 세션 fetch 타이밍 불일치 문제 해결: 세션 fetch 타이밍 불일치로 인해 로그인 직후 페이지가 튕기는 현상(네비게이션 초기화)을 해결했습니다.
- 추후 개선 예정: 세션 확인 전 화면 공백을 방지하기 위한 임시 로딩 상태 추가는 후속 작업으로 진행될 예정입니다.
  
## 🧐 관련 이슈
[[FE] 클라이언트 인증 저장소 리팩토링(LocalStorage → Cookie)](https://daechi-online.atlassian.net/browse/BTS-299?atlOrigin=eyJpIjoiYTgxNjEyMjYyYzVlNGZjYjg2ZDAwZmY0OTgzNDhiODgiLCJwIjoiaiJ9)
[[Login] 토큰 재발급 API (GET /api/auth/refresh) 호출 시 500 Internal Server Error 발생합니다.](https://daechi-online.atlassian.net/jira/software/c/projects/QA/list?jql=project%20%3D%20QA%20ORDER%20BY%20created%20DESC&selectedIssue=QA-6)

## 📷 스크린샷 or 코드 (선택사항)
<img width="1310" height="530" alt="image" src="https://github.com/user-attachments/assets/61d82846-4d6d-4cb9-ba56-55a52bfc89eb" />

<img width="845" height="281" alt="image" src="https://github.com/user-attachments/assets/04dad7ba-75c0-43f2-84fb-7bee6b47b9ba" />
