### PR TITLE
fix : 로컬환경에서도 로그인/로그아웃 작동하도록 수정

### DIFF
--- a/src/app/api/v1/auth/logout/route.ts
+++ b/src/app/api/v1/auth/logout/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { serverEnv } from '@/shared/constants/api';
+import { applySetCookies, extractErrorMessage, safeJson } from '@/shared/lib';
+
+if (!serverEnv.backendApiUrl) throw new Error('BASE_URL is not defined');
+
+export async function POST(request: NextRequest) {
+  const cookieHeader = request.headers.get('cookie');
+  const logoutResponse = await fetch(`${serverEnv.backendApiUrl}/auth/logout`, {
+    method: 'POST',
+    headers: cookieHeader ? { Cookie: cookieHeader } : undefined,
+    cache: 'no-store',
+  });
+
+  const payload = await safeJson(logoutResponse);
+
+  const response =
+    logoutResponse.status === 204
+      ? new NextResponse(null, { status: logoutResponse.status })
+      : NextResponse.json(payload ?? null, {
+          status: logoutResponse.status,
+          headers: {
+            'Content-Type':
+              logoutResponse.headers.get('Content-Type') ?? 'application/json',
+          },
+        });
+
+  applySetCookies(logoutResponse, response);
+
+  if (!logoutResponse.ok && logoutResponse.status !== 204) {
+    const message = extractErrorMessage(payload) ?? '로그아웃에 실패했습니다.';
+    return NextResponse.json({ message }, { status: logoutResponse.status });
+  }
+
+  return response;
+}

--- a/src/entities/member/infrastructure/member.repository.ts
+++ b/src/entities/member/infrastructure/member.repository.ts
@@ -32,7 +32,7 @@ const getCurrentMember = async (): Promise<MemberDTO | null> => {
  * useAuth의 useLogout에서 mutationFn으로 사용
  * ────────────────────────────────────────────────────*/
 const logout = async (): Promise<void> => {
-  return api.private.post('/auth/logout');
+  return api.bff.client.post('/api/v1/auth/logout');
 };
 
 /* ─────────────────────────────────────────────────────

--- a/src/features/auth/hooks/use-auth.ts
+++ b/src/features/auth/hooks/use-auth.ts
@@ -48,7 +48,7 @@ export const useLogout = () => {
 // 인증 상태, 액션을 제공하는 허브
 export const useAuth = () => {
   const { mutate: login, isPending: isLoggingIn } = useLogin();
-  const { mutate: logout, isPending: isLoggingOut } = useLogout();
+  const { mutateAsync: logout, isPending: isLoggingOut } = useLogout();
   const { member, refresh } = useSession();
   return { member, logout, isLoggingOut, login, isLoggingIn, refresh };
 };

--- a/src/features/auth/services/api.ts
+++ b/src/features/auth/services/api.ts
@@ -17,9 +17,7 @@ export const authService = {
     });
   },
   logout: async () => {
-logout: async () => {
-  return api.bff.client.post('/api/v1/auth/logout');
-},
+    return api.bff.client.post('/api/v1/auth/logout');
   },
   getSession: async () => {
     try {

--- a/src/features/auth/services/api.ts
+++ b/src/features/auth/services/api.ts
@@ -17,7 +17,9 @@ export const authService = {
     });
   },
   logout: async () => {
-    return api.private.post('/auth/logout');
+    return api.bff.client.post('/api/v1/auth/logout', {
+      withCredentials: true,
+    });
   },
   getSession: async () => {
     try {

--- a/src/features/auth/services/api.ts
+++ b/src/features/auth/services/api.ts
@@ -17,9 +17,9 @@ export const authService = {
     });
   },
   logout: async () => {
-    return api.bff.client.post('/api/v1/auth/logout', {
-      withCredentials: true,
-    });
+logout: async () => {
+  return api.bff.client.post('/api/v1/auth/logout');
+},
   },
   getSession: async () => {
     try {

--- a/src/layout/header.tsx
+++ b/src/layout/header.tsx
@@ -18,12 +18,20 @@ export const Header = () => {
   // const router = useRouter();
   // const { mutate: logout } = useLogoutMutation();
   const { logout } = useAuth();
-  const handleLogout = () => {
-    void logout();
-    // TODO: 세션 유효한지 확인하는 API / Logout API 부재로
-    // window.location 사용 => 추후에 router.replace로 변경
-    window.location.replace(PUBLIC.CORE.INDEX);
-    // router.replace(ROUTE.HOME);
+  const handleLogout = async () => {
+    try {
+      await logout();
+      // TODO: 세션 유효한지 확인하는 API / Logout API 부재로
+      // window.location 사용 => 추후에 router.replace로 변경
+      window.location.replace(PUBLIC.CORE.INDEX);
+      // router.replace(ROUTE.HOME);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : '로그아웃 처리 중 오류가 발생했습니다.';
+      alert(message);
+    }
   };
 
   const roleMetaMap = {

--- a/src/shared/lib/bff/utils.cookies.ts
+++ b/src/shared/lib/bff/utils.cookies.ts
@@ -30,8 +30,16 @@ export const createSessionCookieHeader = (setCookies: string[]): string => {
     .join('; ');
 };
 
+const sanitizeCookieForLocalhost = (cookie: string) => {
+  if (process.env.NODE_ENV === 'production') {
+    return cookie;
+  }
+  // Remove Domain attribute so cookie becomes host-only for localhost.
+  return cookie.replace(/Domain=[^;]+;?\s*/i, '');
+};
+
 export const applySetCookies = (source: Response, target: NextResponse) => {
   collectSetCookies(source).forEach((cookie) => {
-    target.headers.append('Set-Cookie', cookie);
+    target.headers.append('Set-Cookie', sanitizeCookieForLocalhost(cookie));
   });
 };


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 린트 에러가 없습니다.
- [ ] 코드가 올바르게 포맷팅되었습니다.
- [ ] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항

- 로컬에서도 로그인 이후 기능 테스트(알림 등)를 할 수 있도록 수정했습니다-
- * 백엔드에서 내려주는 쿠키에 Domain 이 값이 붙어있어 localhost 에서는 이를 제거하는 식으로 구현
- * 코드를 보니 모든 요청 응답은 BFF 를 통해 전처리 후처리 되는것같아서 이를 통하게 함
- 로그아웃 요청시 바로 페이지 이동이 되어버려 네트워크 요청이 취소되어서 mutateAync 와 await를 사용함
- 로컬에선 잘 되는데 dev 서버에서 잘 될지 테스트가 필요함 
 
## 🧐 관련 이슈
<!--
- 관련된 이슈 번호를 적어주세요. (ex. `Closes #123`, `Fixes #456`) 
-->

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->

## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
