### PR TITLE
Debug/UI bugs

### DIFF
--- a/src/features/home/ui/session-1.tsx
+++ b/src/features/home/ui/session-1.tsx
@@ -29,7 +29,7 @@ const buttonVariants = cva('flex items-center justify-center text-center', {
 export function Session1() {
   return (
     <section className="mt-[136px] mb-[220px] w-full max-w-[1385px]">
-      <div className="flex-co flex gap-10">
+      <div className="flex gap-10">
         <div>
           <h1 className="justify-center text-[2.5rem] leading-[1.6em] font-normal tracking-[-0.05em]">
             수업 · 숙제 · 피드백까지 <br /> 학습의 흐름을 깔끔하게,

--- a/src/features/study-notes/components/study-note-tab.tsx
+++ b/src/features/study-notes/components/study-note-tab.tsx
@@ -39,8 +39,8 @@ export const StudyNoteTab = ({ studyRoomId, mode, path }: Props) => {
               className={cn(
                 baseCls,
                 isActive
-                  ? 'text-key-color-primary z-20 border-zinc-200 border-b-transparent bg-white font-semibold'
-                  : 'text-text-sub2 z-10 border-zinc-200 bg-transparent hover:bg-zinc-50'
+                  ? 'text-key-color-primary border-zinc-200 border-b-transparent bg-white font-semibold'
+                  : 'text-text-sub2 border-zinc-200 bg-transparent hover:bg-zinc-50'
               )}
             >
               {tab.label}


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
### 1. QnA 페이지 z-index 이슈 해결

**위치**: `src/features/study-notes/components/study-note-tab.tsx`

**수정 내용:** 탭 메뉴의 z-index 제거

```diff
- isActive
-   ? 'text-key-color-primary z-20 border-zinc-200 border-b-transparent bg-white font-semibold'
-   : 'text-text-sub2 z-10 border-zinc-200 bg-transparent hover:bg-zinc-50'
+ isActive
+   ? 'text-key-color-primary border-zinc-200 border-b-transparent bg-white font-semibold'
+   : 'text-text-sub2 border-zinc-200 bg-transparent hover:bg-zinc-50'
```

**수정 이유:** 

- 탭이 `z-20`으로 설정되어 헤더(`z-10`)를 가리는 현상이 발생했습니다.
- z-index를 제거하여 헤더가 자연스럽게 최상위에 위치하도록 수정했습니다.

**스크린샷:**

<img width="729" height="386" alt="image" src="https://github.com/user-attachments/assets/1c9ad0a5-1e9e-43a0-b3ea-9c9fc52c6444" />

### 2. Tailwind CSS 클래스명 오타 수정

**위치:** `src/features/home/ui/session-1.tsx`

**수정 내용:**

```diff
- className="flex-co flex gap-10"
+ className="flex gap-10"
```

**수정 이유:**

- `flex-co`는 사소한 오타로 보여 제거했습니다.

## 💡 개선 제안

현재 구현이 완료되지 않은 부분이거나 우선순위에 따라 추후 적용을 고려하면 좋을 것 같은 부분들입니다.

### 1. alert → 모달 시스템 전환

**현황:** 현재 여러 곳에서 `window.alert()` 사용 중

**제안 이유:** 사용자 경험 일관성 저하

**제안 방향:** 디자인 시스템에 맞는 커스텀 모달로 교체하면 더 나은 사용자 경험을 제공할 수 있을 것 같습니다.

### 2. 로그인 후 라우팅 개선

**현황:**

- 로그인 상태에서 `/` 접근 시 → 로그인 전 홈 화면 표시
- 대시보드가 실질적인 메인 페이지로 보이지만 홈에서 접근 방법이 없습니다.

**제안 방향:**

- 옵션 1. 자동 리다이렉트
- 옵션 2. 홈에 대시보드 이동 버튼 추가

사용자가 로그인 후 어디로 가야 할지 명확하게 안내할 수 있을 것 같습니다.

---
안녕하세요, 코드를 리뷰하면서 발견한 사소한 개선 사항들을 정리했습니다!  
  
코드와 노션 문서를 읽으면서 클린 아키텍처의 실제 적용, BFF 패턴, 체계적인 협업 프로세스 등 많은 것을 배울 수 있었습니다.  
개인 프로젝트에서는 접하기 어려운 구조와 컨벤션들을 보며 실무 수준의 코드 작성 방법을 배울 수 있어서 매우 유익했습니다.

부족한 부분이 있다면 피드백 주시면 감사하겠습니다. 😊
