### PR TITLE
refactor BFF 제거 - authenticated 인스턴스 추가 및 인증 API 직접 통신

### DIFF
--- a/src/entities/member/infrastructure/member.repository.ts
+++ b/src/entities/member/infrastructure/member.repository.ts
@@ -12,9 +12,8 @@ import { adapters } from './member.adapters';
  * ────────────────────────────────────────────────────*/
 const getCurrentMember = async (): Promise<MemberDTO | null> => {
   try {
-    const response = await api.bff.client.get<CommonResponse<MemberDTO>>(
-      '/api/v1/member/info'
-    );
+    const response =
+      await api.private.get<CommonResponse<MemberDTO>>('/members/info');
     const validatedResponse = adapters.fromApi.parse(response);
     return factory.member.create(validatedResponse.data);
   } catch (error: unknown) {
@@ -32,7 +31,7 @@ const getCurrentMember = async (): Promise<MemberDTO | null> => {
  * useAuth의 useLogout에서 mutationFn으로 사용
  * ────────────────────────────────────────────────────*/
 const logout = async (): Promise<void> => {
-  return api.bff.client.post('/api/v1/auth/logout', undefined, {
+  return api.authenticated.post('/auth/logout', undefined, {
     withCredentials: true,
   });
 };

--- a/src/features/auth/hooks/use-auth.ts
+++ b/src/features/auth/hooks/use-auth.ts
@@ -15,7 +15,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 export const useLogin = () => {
   const queryClient = useQueryClient();
   const loginRequest = async (body: LoginBody) => {
-    return await api.bff.client.post('/api/v1/auth/login', body, {
+    return await api.authenticated.post('/auth/login', body, {
       withCredentials: true,
     });
   };

--- a/src/features/auth/services/api.ts
+++ b/src/features/auth/services/api.ts
@@ -12,20 +12,19 @@ import { CommonResponse } from '@/types';
 
 export const authService = {
   login: async (body: LoginBody) => {
-    await api.bff.client.post('/api/v1/auth/login', body, {
+    return await api.authenticated.post('/auth/login', body, {
       withCredentials: true,
     });
   },
   logout: async () => {
-    return api.bff.client.post('/api/v1/auth/logout', undefined, {
+    return api.authenticated.post('/auth/logout', undefined, {
       withCredentials: true,
     });
   },
   getSession: async () => {
     try {
-      const response = await api.bff.client.get<CommonResponse<MemberDTO>>(
-        '/api/v1/member/info'
-      );
+      const response =
+        await api.private.get<CommonResponse<MemberDTO>>('/members/info');
       const validatedResponse = adapters.fromApi.parse(response);
       return factory.member.create(validatedResponse.data);
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,7 +23,7 @@ const PUBLIC_PATHS = new Set<string>([
   '/',
   '/login',
   '/register',
-  '/api/v1/auth/login',
+  // '/api/v1/auth/login',
 ]);
 
 // next.js 인프라 내부로의 요청인지 판단

--- a/src/shared/api/http/http.client.ts
+++ b/src/shared/api/http/http.client.ts
@@ -27,6 +27,9 @@ const publicApi = createApi(http.public);
 // NOTE: authApi - 로그인(인증 쿠키) 필요 API
 const privateApi = createApi(http.private);
 
+// NOTE: authenticatedApi - 인증 관련 API
+const authenticatedApi = createApi(http.authenticated);
+
 // NOTE: BFF 전용
 const clientToBffApi = createApi(http.bff.client);
 
@@ -37,5 +40,6 @@ const bff = { client: clientToBffApi, server: serverToBffApi };
 export const api = {
   public: publicApi,
   private: privateApi,
+  authenticated: authenticatedApi,
   bff,
 };

--- a/src/shared/api/http/http.transport.ts
+++ b/src/shared/api/http/http.transport.ts
@@ -1,7 +1,7 @@
 import { env } from '@/shared/constants/api';
 import axios from 'axios';
 
-const isServer = typeof window === 'undefined';
+// const isServer = typeof window === 'undefined';
 
 // NOTE: 인증 필요한 요청 전용 (쿠키 자동 포함)
 const privateHttp = axios.create({
@@ -10,7 +10,9 @@ const privateHttp = axios.create({
    * 따라서 /api/v1 경로로 요청하도록 설정하며 app/v1/[...path] 라우터 핸들러를 통해 쿠키를 붙여 백엔드로 프록시
    * ────────────────────────────────────────────────────*/
   // baseURL: env.backendApiUrl,
-  baseURL: isServer ? env.backendApiUrl : '/api/v1',
+  // baseURL: isServer ? env.backendApiUrl : '/api/v1',
+  baseURL:
+    process.env.NODE_ENV === 'development' ? '/api/v1' : env.backendApiUrl,
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',

--- a/src/shared/api/http/http.transport.ts
+++ b/src/shared/api/http/http.transport.ts
@@ -1,18 +1,9 @@
 import { env } from '@/shared/constants/api';
 import axios from 'axios';
 
-// const isServer = typeof window === 'undefined';
-
 // NOTE: 인증 필요한 요청 전용 (쿠키 자동 포함)
 const privateHttp = axios.create({
-  /* ─────────────────────────────────────────────────────
-   * 로컬 환경에서는 Cross site 문제로 localhost -> 백엔드서버 쿠키요청이 안됨
-   * 따라서 /api/v1 경로로 요청하도록 설정하며 app/v1/[...path] 라우터 핸들러를 통해 쿠키를 붙여 백엔드로 프록시
-   * ────────────────────────────────────────────────────*/
-  // baseURL: env.backendApiUrl,
-  // baseURL: isServer ? env.backendApiUrl : '/api/v1',
-  baseURL:
-    process.env.NODE_ENV === 'development' ? '/api/v1' : env.backendApiUrl,
+  baseURL: env.backendApiUrl,
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
@@ -23,6 +14,15 @@ const privateHttp = axios.create({
 const publicHttp = axios.create({
   baseURL: env.backendApiUrl,
   withCredentials: false,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// NOTE: 인증 API 전용 (인터셉터 절대 붙이면 안 됨)
+const authenticatedHttp = axios.create({
+  baseURL: env.backendApiUrl,
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -55,5 +55,6 @@ const bff = {
 export const http = {
   public: publicHttp,
   private: privateHttp,
+  authenticated: authenticatedHttp,
   bff,
 };

--- a/src/shared/api/http/refresh.ts
+++ b/src/shared/api/http/refresh.ts
@@ -1,7 +1,7 @@
 import { http } from './http.transport';
 
 export const refreshSession = async (): Promise<void> => {
-  await http.bff.client.get('/api/v1/auth/refresh');
+  await http.authenticated.get('/auth/refresh');
 };
 
 let refreshPromise: Promise<void> | null = null;


### PR DESCRIPTION
* 로컬 환경에서 쿠키 Secure 속성 이슈로 테스트가 불가하여 배포 환경 확인을 위한 PR입니다. 
* **작업 진행 중이며, 추가 보완 예정입니다.**

## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
1. authenticated HTTP 인스턴스 추가
  - 인증 API 전용 (로그인, 토큰 갱신, 로그아웃)
  - 인터셉터 없음
  - 백엔드 직접 통신
2. API 전환 완료
  - 로그인, 로그아웃, 토큰 갱신: api.bff.client → api.authenticated
  - 회원 정보: api.bff.client → api.private
3. 기타 수정
  - PUBLIC_PATHS에서 /api/v1/auth/login 제거

## 📷 스크린샷 or 코드 (선택사항)
`/login`
<img width="500" height="109" alt="image" src="https://github.com/user-attachments/assets/4b702328-8d5c-4771-b99e-71582cdbf9f7" />
<img width="289" height="104" alt="image" src="https://github.com/user-attachments/assets/82339b49-7630-4d95-86c4-fad4c7ff3d1d" />

`/info`
<img width="622" height="103" alt="image" src="https://github.com/user-attachments/assets/34a8a8c7-6e69-429e-b417-6983820d194e" />

- 로그인에 성공하지만 회원 정보 조회에 실패합니다. 배포 환경에서의 테스트를 위해 먼저 pr 올립니다.

