### PR TITLE
fix : 개발 화면 백엔드 주소 운영->개발로 정정

### DIFF
--- a/src/shared/constants/api/config.env.ts
+++ b/src/shared/constants/api/config.env.ts
@@ -11,14 +11,22 @@ const sanitize = (value: string | undefined) =>
  * - 서버 사이드: VERCEL_ENV를 사용하여 프로덕션/개발 환경 구분
  * - 클라이언트 사이드: window.location.hostname을 사용하여 런타임에 환경 구분
  */
+const serverHostname = process.env.VERCEL_URL;
+
 const getBackendUrl = () => {
   // 서버 사이드: VERCEL_ENV 확인
   if (typeof window === 'undefined') {
     const vercelEnv = process.env.VERCEL_ENV;
     if (vercelEnv === 'production') {
+      // 개발 화면인 경우 '개발' 서버로 요청
+      if (serverHostname === 'dev.d-edu.site') {
+        return DEFAULT_DEV_BACKEND_API_URL;
+      }
+      // 운영 화면인 경우 '운영' 서버로 요청
       return DEFAULT_PROD_BACKEND_API_URL;
     }
-    // preview, development, 또는 로컬
+
+    // preview, development, 또는 로컬의 경우 '개발' 서버로 요청
     return DEFAULT_DEV_BACKEND_API_URL;
   }
 


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 린트 에러가 없습니다.
- [ ] 코드가 올바르게 포맷팅되었습니다.
- [ ] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
토큰 없는 public 요청의 경우 백엔드 서버로 바로 요청을 해야맞지만, 현재 구조상 임시로 BFF Next.js 서버를 거치도록 가고 있음. (window === 'undefined'). 

이 경우 VERCEL_ENV 가 production 인 경우(즉 배포된 화면)에는 백엔드 운영서버로 주소 요청을 하는데, 

이전에 develop 브렌치가 preview URL 일 때는 해당 로직을 거치지 않았으나 버셀 로그인을 하지 않고도 개발서버를 봐야한다는 요청과 판단에 따라 develop 브렌치도 production 으로 변경했고 현재 개발화면에서도 백엔드 개발서버가 아닌 운영서버로 전송되는 오류 발생.

중간에 조건분기 추가하여 서버사이드 요청에서도 개발화면이면 (serverHostname === 'dev.d-edu.site') 개발 운영서버로 전송되도록 정정함.
  
## 🧐 관련 이슈
<!--
- 관련된 이슈 번호를 적어주세요. (ex. `Closes #123`, `Fixes #456`) 
-->

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->

## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
