### PR TITLE
BTS 408 : 알림 기능 구현

### DIFF
--- a/src/app/api/v1/[...path]/route.ts
+++ b/src/app/api/v1/[...path]/route.ts
@@ -70,7 +70,12 @@ async function handleRequest(
 
   // 요청 본문 처리
   let requestBody: string | undefined;
-  if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
+  if (
+    method === 'POST' ||
+    method === 'PUT' ||
+    method === 'PATCH' ||
+    method === 'DELETE'
+  ) {
     try {
       requestBody = await request.text();
     } catch {

--- a/src/entities/notification/core/notification.domain.schema.ts
+++ b/src/entities/notification/core/notification.domain.schema.ts
@@ -4,15 +4,16 @@ import { ko } from 'date-fns/locale';
 import { z } from 'zod';
 
 /* ─────────────────────────────────────────────────────
- * type -> category 변환 매핑
+ * category -> 한글 변환 매핑
  * ────────────────────────────────────────────────────*/
-const TYPE_TO_CATEGORY_MAP = {
+const CATEGORY_TO_KOREAN = {
+  TEACHING_NOTE: '수업노트',
   SYSTEM: '공지사항',
   CONNECTION_REQUEST: '연결 요청',
 };
 
-const getCategory = (type: string): string =>
-  TYPE_TO_CATEGORY_MAP[type as keyof typeof TYPE_TO_CATEGORY_MAP];
+const getCategoryKorean = (type: string): string =>
+  CATEGORY_TO_KOREAN[type as keyof typeof CATEGORY_TO_KOREAN];
 
 /* ─────────────────────────────────────────────────────
  * base 스키마를 가공하여 도메인 기본 구조 생성
@@ -24,9 +25,9 @@ const NotificationShape = base.schema
   .required({
     id: true,
     message: true,
-    type: true,
+    category: true,
     targetId: true,
-    read: true,
+    isRead: true,
   })
   .extend({
     regDate: z.preprocess((val) => {
@@ -43,16 +44,15 @@ const NotificationShape = base.schema
  * ────────────────────────────────────────────────────*/
 const NotificationSchema = NotificationShape.transform((notification) => ({
   ...notification,
-  category: getCategory(notification.type),
+  categoryKorean: getCategoryKorean(notification.category),
   relativeTime: formatDistanceToNow(notification.regDate, {
     addSuffix: true,
     locale: ko,
   }),
-  isRead: notification.read,
 }));
 
 export const domain = {
   schema: NotificationSchema,
   shape: NotificationShape,
-  type: base.type,
+  category: base.category,
 };

--- a/src/entities/notification/core/notification.domain.schema.ts
+++ b/src/entities/notification/core/notification.domain.schema.ts
@@ -6,14 +6,31 @@ import { z } from 'zod';
 /* ─────────────────────────────────────────────────────
  * category -> 한글 변환 매핑
  * ────────────────────────────────────────────────────*/
-const CATEGORY_TO_KOREAN = {
+const CATEGORY_TO_KOREAN: Record<string, string> = {
   TEACHING_NOTE: '수업노트',
   SYSTEM: '공지사항',
   CONNECTION_REQUEST: '연결 요청',
 };
 
-const getCategoryKorean = (type: string): string =>
-  CATEGORY_TO_KOREAN[type as keyof typeof CATEGORY_TO_KOREAN];
+const getCategoryKorean = (category: string): string =>
+  CATEGORY_TO_KOREAN[category as keyof typeof CATEGORY_TO_KOREAN] || '기타';
+
+/* ─────────────────────────────────────────────────────
+ * category -> URL 변환 매핑
+ * ────────────────────────────────────────────────────*/
+const CATEGORY_TO_ROUTE: Record<string, string | null> = {
+  TEACHING_NOTE: '/study-rooms/1/note',
+  CONNECTION_REQUEST: null,
+  SYSTEM: null,
+};
+
+const getTargetUrl = (category: string, targetId: number): string | null => {
+  const basePath =
+    CATEGORY_TO_ROUTE[category as keyof typeof CATEGORY_TO_ROUTE];
+
+  if (!basePath) return null;
+  return `${basePath}/${targetId}`;
+};
 
 /* ─────────────────────────────────────────────────────
  * base 스키마를 가공하여 도메인 기본 구조 생성
@@ -45,6 +62,7 @@ const NotificationShape = base.schema
 const NotificationSchema = NotificationShape.transform((notification) => ({
   ...notification,
   categoryKorean: getCategoryKorean(notification.category),
+  targetUrl: getTargetUrl(notification.category, notification.targetId),
   relativeTime: formatDistanceToNow(notification.regDate, {
     addSuffix: true,
     locale: ko,

--- a/src/entities/notification/core/notification.domain.schema.ts
+++ b/src/entities/notification/core/notification.domain.schema.ts
@@ -7,9 +7,11 @@ import { z } from 'zod';
  * category -> 한글 변환 매핑
  * ────────────────────────────────────────────────────*/
 const CATEGORY_TO_KOREAN: Record<string, string> = {
-  TEACHING_NOTE: '수업노트',
   SYSTEM: '공지사항',
-  CONNECTION_REQUEST: '연결 요청',
+  HOMEWORK: '과제',
+  TEACHING_NOTE: '수업노트',
+  STUDY_ROOM: '스터디룸 초대',
+  QNA: '질문',
 };
 
 const getCategoryKorean = (category: string): string =>
@@ -18,18 +20,18 @@ const getCategoryKorean = (category: string): string =>
 /* ─────────────────────────────────────────────────────
  * category -> URL 변환 매핑
  * ────────────────────────────────────────────────────*/
-const CATEGORY_TO_ROUTE: Record<string, string | null> = {
-  TEACHING_NOTE: '/study-rooms/1/note',
-  CONNECTION_REQUEST: null,
-  SYSTEM: null,
-};
-
 const getTargetUrl = (category: string, targetId: number): string | null => {
-  const basePath =
-    CATEGORY_TO_ROUTE[category as keyof typeof CATEGORY_TO_ROUTE];
-
-  if (!basePath) return null;
-  return `${basePath}/${targetId}`;
+  switch (category) {
+    case 'TEACHING_NOTE':
+      return `/study-rooms/1/note/${targetId}`;
+    case 'STUDY_ROOM':
+      return `/study-rooms/${targetId}/note`;
+    // TODO URL 확인 후 추가
+    case 'QNA':
+    case 'HOMEWORK':
+    default:
+      return null;
+  }
 };
 
 /* ─────────────────────────────────────────────────────
@@ -44,7 +46,7 @@ const NotificationShape = base.schema
     message: true,
     category: true,
     targetId: true,
-    isRead: true,
+    read: true,
   })
   .extend({
     regDate: z.preprocess((val) => {
@@ -67,6 +69,7 @@ const NotificationSchema = NotificationShape.transform((notification) => ({
     addSuffix: true,
     locale: ko,
   }),
+  isRead: notification.read,
 }));
 
 export const domain = {

--- a/src/entities/notification/core/notification.domain.schema.ts
+++ b/src/entities/notification/core/notification.domain.schema.ts
@@ -20,15 +20,26 @@ const getCategoryKorean = (category: string): string =>
 /* ─────────────────────────────────────────────────────
  * category -> URL 변환 매핑
  * ────────────────────────────────────────────────────*/
-const getTargetUrl = (category: string, targetId: number): string | null => {
+const getTargetUrl = (
+  category: string,
+  metadata: {
+    qnaId?: string;
+    studyRoomId?: string;
+    teachingNoteId?: string;
+    noticeId?: string;
+    homeworkId?: string;
+  }
+): string | null => {
   switch (category) {
     case 'TEACHING_NOTE':
-      return `/study-rooms/1/note/${targetId}`;
+      return `/study-rooms/${metadata.studyRoomId}/note/${metadata.teachingNoteId}`;
     case 'STUDY_ROOM':
-      return `/study-rooms/${targetId}/note`;
-    // TODO URL 확인 후 추가
+      return `/study-rooms/${metadata.studyRoomId}/note`;
     case 'QNA':
+      return `/study-rooms/${metadata.studyRoomId}/qna/${metadata.qnaId}`;
+    // TODO
     case 'HOMEWORK':
+    case 'SYSTEM':
     default:
       return null;
   }
@@ -45,7 +56,7 @@ const NotificationShape = base.schema
     id: true,
     message: true,
     category: true,
-    targetId: true,
+    targetMetadata: true,
     read: true,
   })
   .extend({
@@ -64,7 +75,7 @@ const NotificationShape = base.schema
 const NotificationSchema = NotificationShape.transform((notification) => ({
   ...notification,
   categoryKorean: getCategoryKorean(notification.category),
-  targetUrl: getTargetUrl(notification.category, notification.targetId),
+  targetUrl: getTargetUrl(notification.category, notification.targetMetadata),
   relativeTime: formatDistanceToNow(notification.regDate, {
     addSuffix: true,
     locale: ko,

--- a/src/entities/notification/infrastructure/notification.dto.schema.ts
+++ b/src/entities/notification/infrastructure/notification.dto.schema.ts
@@ -30,5 +30,5 @@ export const dto = {
   schema: NotificationDtoSchema,
   envelope: NotificationEnvelopeSchema,
   response: NotificationAnyResponseSchema,
-  type: base.type,
+  category: base.category,
 };

--- a/src/entities/notification/infrastructure/notification.keys.ts
+++ b/src/entities/notification/infrastructure/notification.keys.ts
@@ -1,4 +1,5 @@
 export const notificationKeys = {
   all: ['notification'] as const,
   list: () => [...notificationKeys.all, 'list'] as const,
+  unread: () => [...notificationKeys.all, 'unread'] as const,
 };

--- a/src/entities/notification/infrastructure/notification.repository.ts
+++ b/src/entities/notification/infrastructure/notification.repository.ts
@@ -5,7 +5,6 @@ import {
 } from '@/entities/notification/types';
 import { api } from '@/shared/api';
 import { CommonResponse } from '@/types';
-import axios from 'axios';
 
 import { adapters } from './notification.adapters';
 
@@ -14,36 +13,28 @@ import { adapters } from './notification.adapters';
  * useNotificationQuery의 queryFn으로 사용
  * ────────────────────────────────────────────────────*/
 const getNotificationList = async (): Promise<FrontendNotification[]> => {
-  try {
-    const response =
-      await api.private.get<CommonResponse<NotificationDTO[]>>(
-        '/notification/all'
-      );
-
-    const validatedResponse = adapters.fromApi.parse(response);
-
-    return notificationMapper.toDomainList(validatedResponse.data ?? []);
-  } catch (error: unknown) {
-    if (!axios.isAxiosError(error)) throw error;
-    // TODO api 인터셉터 내부에서 처리
-    if (!error.response) throw error;
-
-    const status = error.response.status;
-    if (status === 401 || status === 403) return [];
-
-    throw error;
-  }
+  const response =
+    await api.private.get<CommonResponse<NotificationDTO[]>>(
+      '/notification/all'
+    );
+  const validatedResponse = adapters.fromApi.parse(response);
+  return notificationMapper.toDomainList(validatedResponse.data ?? []);
 };
 
 /* ─────────────────────────────────────────────────────
  * [Update] 알림 읽음 처리
  * useMutation의 mutationFn으로 처리
  * ────────────────────────────────────────────────────*/
-// TODO 1. 알림 읽음 2. 미확인 알림
+const markAsRead = async (notificationIds: number[]): Promise<void> => {
+  await api.private.patch('/notification/read', { notificationIds });
+};
+
+// TODO 미확인 알림 조회
 
 export const repository = {
   notification: {
     getList: getNotificationList,
+    markAsRead: markAsRead,
     // TODO 추가
   },
 };

--- a/src/entities/notification/infrastructure/notification.repository.ts
+++ b/src/entities/notification/infrastructure/notification.repository.ts
@@ -10,7 +10,6 @@ import { adapters } from './notification.adapters';
 
 /* ─────────────────────────────────────────────────────
  * [Read] 알림 목록 조회
- * useNotificationQuery의 queryFn으로 사용
  * ────────────────────────────────────────────────────*/
 const getNotificationList = async (): Promise<FrontendNotification[]> => {
   const response =
@@ -23,10 +22,20 @@ const getNotificationList = async (): Promise<FrontendNotification[]> => {
 
 /* ─────────────────────────────────────────────────────
  * [Update] 알림 읽음 처리
- * useMutation의 mutationFn으로 처리
  * ────────────────────────────────────────────────────*/
 const markAsRead = async (notificationIds: number[]): Promise<void> => {
   await api.private.patch('/notification/read', { notificationIds });
+};
+
+/* ─────────────────────────────────────────────────────
+ * [Delete] 알림 삭제
+ * ────────────────────────────────────────────────────*/
+const deleteNotifications = async (
+  notificationIds: number[]
+): Promise<void> => {
+  await api.private.delete('/notification', {
+    data: { notificationIds },
+  });
 };
 
 // TODO 미확인 알림 조회
@@ -35,6 +44,7 @@ export const repository = {
   notification: {
     getList: getNotificationList,
     markAsRead: markAsRead,
+    delete: deleteNotifications,
     // TODO 추가
   },
 };

--- a/src/entities/notification/infrastructure/notification.repository.ts
+++ b/src/entities/notification/infrastructure/notification.repository.ts
@@ -21,6 +21,15 @@ const getNotificationList = async (): Promise<FrontendNotification[]> => {
 };
 
 /* ─────────────────────────────────────────────────────
+ * [Read] 미확인 알림 조회
+ * ────────────────────────────────────────────────────*/
+const getUnreadNotifications = async () => {
+  const response = await api.private.get('/notification/unread');
+  const validatedResponse = adapters.fromApi.parse(response);
+  return notificationMapper.toDomainList(validatedResponse.data ?? []);
+};
+
+/* ─────────────────────────────────────────────────────
  * [Update] 알림 읽음 처리
  * ────────────────────────────────────────────────────*/
 const markAsRead = async (notificationIds: number[]): Promise<void> => {
@@ -38,13 +47,11 @@ const deleteNotifications = async (
   });
 };
 
-// TODO 미확인 알림 조회
-
 export const repository = {
   notification: {
     getList: getNotificationList,
+    getUnread: getUnreadNotifications,
     markAsRead: markAsRead,
     delete: deleteNotifications,
-    // TODO 추가
   },
 };

--- a/src/entities/notification/infrastructure/notification.repository.ts
+++ b/src/entities/notification/infrastructure/notification.repository.ts
@@ -22,9 +22,10 @@ const getNotificationList = async (): Promise<FrontendNotification[]> => {
 
     const validatedResponse = adapters.fromApi.parse(response);
 
-    return notificationMapper.toDomianList(validatedResponse.data ?? []);
+    return notificationMapper.toDomainList(validatedResponse.data ?? []);
   } catch (error: unknown) {
     if (!axios.isAxiosError(error)) throw error;
+    // TODO api 인터셉터 내부에서 처리
     if (!error.response) throw error;
 
     const status = error.response.status;

--- a/src/entities/notification/mapper/notification.mapper.ts
+++ b/src/entities/notification/mapper/notification.mapper.ts
@@ -12,6 +12,6 @@ import { NotificationDTO } from '@/entities/notification/types';
 export const notificationMapper = {
   toDomain: (dto: NotificationDTO) => domain.schema.parse(dto),
 
-  toDomianList: (dtos: NotificationDTO[]) =>
+  toDomainList: (dtos: NotificationDTO[]) =>
     dtos.map(notificationMapper.toDomain),
 };

--- a/src/entities/notification/schema.ts
+++ b/src/entities/notification/schema.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
 
 const NotificationCategorySchema = z.enum([
-  'TEACHING_NOTE',
   'SYSTEM',
-  'CONNECTION_REQUEST',
-  // TODO: 추가 카테고리
+  'HOMEWORK',
+  'TEACHING_NOTE',
+  'STUDY_ROOM',
+  'QNA',
 ]);
 
 const NotificationSchema = z.object({
@@ -13,7 +14,7 @@ const NotificationSchema = z.object({
   category: NotificationCategorySchema,
   targetId: z.number().int().nonnegative(),
   regDate: z.string().nullable(),
-  isRead: z.boolean(),
+  read: z.boolean(),
 });
 
 export const base = {

--- a/src/entities/notification/schema.ts
+++ b/src/entities/notification/schema.ts
@@ -8,11 +8,27 @@ const NotificationCategorySchema = z.enum([
   'QNA',
 ]);
 
+/**
+ * targetMetadata: 카테고리별 메타데이터
+ * - QNA: qnaId, studyRoomId
+ * - STUDY_ROOM: studyRoomId
+ * - TEACHING_NOTE: teachingNoteId
+ * TODO
+ * - SYSTEM: noticeId (예정)
+ * - HOMEWORK: homeworkId (예정)
+ */
+const TargetMetadataSchema = z.object({
+  qnaId: z.string().optional(),
+  studyRoomId: z.string().optional(),
+  teachingNoteId: z.string().optional(),
+  homeworkId: z.string().optional(),
+});
+
 const NotificationSchema = z.object({
   id: z.number().int().nonnegative(),
   message: z.string(),
   category: NotificationCategorySchema,
-  targetId: z.number().int().nonnegative(),
+  targetMetadata: TargetMetadataSchema,
   regDate: z.string().nullable(),
   read: z.boolean(),
 });

--- a/src/entities/notification/schema.ts
+++ b/src/entities/notification/schema.ts
@@ -1,17 +1,22 @@
 import { z } from 'zod';
 
-const NotificationTypeSchema = z.enum(['SYSTEM', 'CONNECTION_REQUEST']);
+const NotificationCategorySchema = z.enum([
+  'TEACHING_NOTE',
+  'SYSTEM',
+  'CONNECTION_REQUEST',
+  // TODO: 추가 카테고리
+]);
 
 const NotificationSchema = z.object({
   id: z.number().int().nonnegative(),
   message: z.string(),
-  type: NotificationTypeSchema,
+  category: NotificationCategorySchema,
   targetId: z.number().int().nonnegative(),
   regDate: z.string().nullable(),
-  read: z.boolean(),
+  isRead: z.boolean(),
 });
 
 export const base = {
-  type: NotificationTypeSchema,
+  category: NotificationCategorySchema,
   schema: NotificationSchema,
 };

--- a/src/entities/notification/types/index.ts
+++ b/src/entities/notification/types/index.ts
@@ -3,6 +3,6 @@ import { dto } from '@/entities/notification/infrastructure';
 import { z } from 'zod';
 
 export type NotificationDTO = z.infer<typeof dto.schema>;
-export type NotificationType = z.infer<typeof dto.type>;
+export type NotificationCategory = z.infer<typeof dto.category>;
 
 export type FrontendNotification = z.infer<typeof domain.schema>;

--- a/src/features/notifications/api/notifications.api.ts
+++ b/src/features/notifications/api/notifications.api.ts
@@ -6,4 +6,10 @@ export const notificationsApi = {
    * @returns FrontendNotification[]
    */
   getList: () => repository.notification.getList(),
+  /**
+   * 알림 읽음 처리
+   * @param notificationIds number[] 읽음처리할 알림 id 배열
+   */
+  markAsRead: (notificationIds: number[]) =>
+    repository.notification.markAsRead(notificationIds),
 };

--- a/src/features/notifications/api/notifications.api.ts
+++ b/src/features/notifications/api/notifications.api.ts
@@ -7,14 +7,19 @@ export const notificationsApi = {
    */
   getList: () => repository.notification.getList(),
   /**
+   * 미확인 알림 조회
+   * @returns FrontendNotification[]
+   */
+  getUnread: () => repository.notification.getUnread(),
+  /**
    * 알림 읽음 처리
    * @param notificationIds 읽음처리할 알림 id 배열
    */
   markAsRead: (notificationIds: number[]) =>
     repository.notification.markAsRead(notificationIds),
   /**
-   * 알림 삭제 처리
-   * @param notificationIds 삭제처리할 알림 id 배열
+   * 알림 삭제
+   * @param notificationIds 삭제할 알림 id 배열
    */
   delete: (notificationIds: number[]) =>
     repository.notification.delete(notificationIds),

--- a/src/features/notifications/api/notifications.api.ts
+++ b/src/features/notifications/api/notifications.api.ts
@@ -8,8 +8,14 @@ export const notificationsApi = {
   getList: () => repository.notification.getList(),
   /**
    * 알림 읽음 처리
-   * @param notificationIds number[] 읽음처리할 알림 id 배열
+   * @param notificationIds 읽음처리할 알림 id 배열
    */
   markAsRead: (notificationIds: number[]) =>
     repository.notification.markAsRead(notificationIds),
+  /**
+   * 알림 삭제 처리
+   * @param notificationIds 삭제처리할 알림 id 배열
+   */
+  delete: (notificationIds: number[]) =>
+    repository.notification.delete(notificationIds),
 };

--- a/src/features/notifications/components/notification-popover.tsx
+++ b/src/features/notifications/components/notification-popover.tsx
@@ -1,7 +1,13 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+
+import { FrontendNotification } from '@/entities/notification';
 import NotificationIcon from '@/features/notifications/components/notification-icon';
-import { useNotifications } from '@/features/notifications/hooks/use-notifications';
+import {
+  useMarkAsRead,
+  useNotifications,
+} from '@/features/notifications/hooks/use-notifications';
 import {
   Popover,
   PopoverClose,
@@ -19,10 +25,21 @@ type NotificationPopoverProps = {
 export function NotificationPopover({
   defaultOpen = false,
 }: NotificationPopoverProps) {
+  const router = useRouter();
   const { data, isLoading, error } = useNotifications();
   const session = useMemberStore((s) => s.member);
+  const markAsRead = useMarkAsRead();
+
   const notifications = data ?? [];
   const hasNotifications = notifications.length > 0;
+
+  const handleNotificationClick = (notification: FrontendNotification) => {
+    if (!notification.isRead) markAsRead.mutate([notification.id]);
+    if (notification.targetUrl) router.push(notification.targetUrl);
+  };
+
+  // TODO 전체 읽음 처리
+  const handleMarkAllRead = () => {};
 
   return (
     <Popover defaultOpen={defaultOpen}>
@@ -35,7 +52,7 @@ export function NotificationPopover({
             // GNB 알림 아이콘 클릭 이벤트 전송
             trackGnbAlarmClick(session?.role ?? null);
           }}
-        > 
+        >
           <NotificationIcon hasNotifications={hasNotifications} />
           <span className="sr-only">알림</span>
         </button>
@@ -75,6 +92,7 @@ export function NotificationPopover({
                   'flex items-start justify-between border-b px-6 py-4 transition-colors',
                   'hover:bg-gray-50'
                 )}
+                onClick={() => handleNotificationClick(item)}
               >
                 <div className="flex-1">
                   <p
@@ -115,6 +133,7 @@ export function NotificationPopover({
           <button
             type="button"
             className="cursor-pointer hover:underline"
+            onClick={handleMarkAllRead}
           >
             전체 삭제
           </button>

--- a/src/features/notifications/components/notification-popover.tsx
+++ b/src/features/notifications/components/notification-popover.tsx
@@ -77,10 +77,14 @@ export function NotificationPopover({
                 )}
               >
                 <div className="flex-1">
-                  <p className="text-xs font-semibold text-gray-500">
-                    {item.category}
+                  <p
+                    className={`text-xs font-semibold text-gray-500 ${item.isRead ? 'font-body2-normal' : 'font-body2-heading'}`}
+                  >
+                    {item.categoryKorean}
                   </p>
-                  <p className="mt-1 text-sm leading-relaxed text-gray-900">
+                  <p
+                    className={`mt-1 text-sm leading-relaxed text-gray-900 ${item.isRead ? 'font-body2-normal' : 'font-body2-heading'}`}
+                  >
                     {item.message}
                   </p>
                 </div>
@@ -117,6 +121,7 @@ export function NotificationPopover({
           <button
             type="button"
             className="flex cursor-pointer items-center gap-2 hover:underline"
+            aria-label="알림 설정"
           >
             ⚙️ 알림 설정
           </button>

--- a/src/features/notifications/components/notification-popover.tsx
+++ b/src/features/notifications/components/notification-popover.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { FrontendNotification } from '@/entities/notification';
 import NotificationIcon from '@/features/notifications/components/notification-icon';
 import {
+  useDeleteNotifications,
   useMarkAsRead,
   useNotifications,
 } from '@/features/notifications/hooks/use-notifications';
@@ -26,13 +27,16 @@ export function NotificationPopover({
   defaultOpen = false,
 }: NotificationPopoverProps) {
   const router = useRouter();
+
   const { data, isLoading, error } = useNotifications();
   const session = useMemberStore((s) => s.member);
   const markAsRead = useMarkAsRead();
+  const deleteNotifications = useDeleteNotifications();
 
   const notifications = data ?? [];
   const hasNotifications = notifications.length > 0;
 
+  // 개별 읽음 처리
   const handleNotificationClick = (notification: FrontendNotification) => {
     if (!notification.isRead) markAsRead.mutate([notification.id]);
     if (notification.targetUrl) router.push(notification.targetUrl);
@@ -40,6 +44,18 @@ export function NotificationPopover({
 
   // TODO 전체 읽음 처리
   const handleMarkAllRead = () => {};
+
+  // 개별 삭제
+  const handleDelete = (id: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    deleteNotifications.mutate([id]);
+  };
+
+  // TODO 전체 삭제
+  const handleDeleteAll = () => {
+    if (!hasNotifications) return;
+  };
 
   return (
     <Popover defaultOpen={defaultOpen}>
@@ -114,6 +130,7 @@ export function NotificationPopover({
                     type="button"
                     className="text-gray-300 hover:text-gray-500"
                     aria-label="알림 삭제"
+                    onClick={(event) => handleDelete(item.id, event)}
                   >
                     🗑️
                   </button>
@@ -130,13 +147,23 @@ export function NotificationPopover({
         )}
 
         <footer className="flex items-center justify-between border-t bg-gray-900 px-6 py-4 text-sm text-white">
-          <button
-            type="button"
-            className="cursor-pointer hover:underline"
-            onClick={handleMarkAllRead}
-          >
-            전체 삭제
-          </button>
+          <div>
+            <button
+              type="button"
+              className="cursor-pointer hover:underline"
+              onClick={handleDeleteAll}
+            >
+              전체 삭제
+            </button>
+            <span aria-hidden> | </span>
+            <button
+              type="button"
+              className="cursor-pointer hover:underline"
+              onClick={handleMarkAllRead}
+            >
+              전체 읽음
+            </button>
+          </div>
           <button
             type="button"
             className="flex cursor-pointer items-center gap-2 hover:underline"

--- a/src/features/notifications/components/notification-popover.tsx
+++ b/src/features/notifications/components/notification-popover.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useReducer, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
@@ -10,7 +10,13 @@ import {
   useDeleteNotifications,
   useMarkAsRead,
   useNotifications,
+  useUnreadNotifications,
 } from '@/features/notifications/hooks/use-notifications';
+import {
+  ConfirmDialog,
+  dialogReducer,
+  initialDialogState,
+} from '@/shared/components/dialog';
 import {
   Popover,
   PopoverClose,
@@ -27,15 +33,23 @@ export function NotificationPopover() {
 
   const session = useMemberStore((s) => s.member);
   const { data, isLoading, error, refetch } = useNotifications();
+  const { data: unread, refetch: refetchUnread } = useUnreadNotifications();
   const markAsRead = useMarkAsRead();
   const deleteNotifications = useDeleteNotifications();
 
   const notifications = data ?? [];
   const hasNotifications = notifications.length > 0;
+  const unreadCount = unread?.length ?? 0;
+
+  const [dialog, dispatch] = useReducer(dialogReducer, initialDialogState);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   useEffect(() => {
-    if (isOpen) refetch();
-  }, [isOpen, refetch]);
+    if (isOpen) {
+      refetch();
+      refetchUnread();
+    }
+  }, [isOpen, refetch, refetchUnread]);
 
   // 개별 읽음 처리
   const handleNotificationClick = (notification: FrontendNotification) => {
@@ -46,8 +60,13 @@ export function NotificationPopover() {
     }
   };
 
-  // TODO 전체 읽음 처리
-  const handleMarkAllRead = () => {};
+  // 전체 읽음 처리
+  const handleMarkAllRead = () => {
+    if (!unreadCount) return;
+
+    const unreadIds = unread?.map((n) => n.id) ?? [];
+    markAsRead.mutate(unreadIds);
+  };
 
   // 개별 삭제
   const handleDelete = (id: number, e: React.MouseEvent) => {
@@ -56,9 +75,14 @@ export function NotificationPopover() {
     deleteNotifications.mutate([id]);
   };
 
-  // TODO 전체 삭제
+  // 전체 삭제
   const handleDeleteAll = () => {
     if (!hasNotifications) return;
+
+    const allIds = notifications.map((n) => n.id) ?? [];
+    deleteNotifications.mutate(allIds);
+
+    dispatch({ type: 'GO_TO_CONFIRM' });
   };
 
   return (
@@ -81,103 +105,133 @@ export function NotificationPopover() {
         </button>
       </PopoverTrigger>
 
-      <PopoverContent className="mr-4 overflow-hidden p-0">
-        <header className="flex items-center justify-between border-b px-6 py-4">
-          <h2 className="text-lg font-semibold">알림</h2>
-          <PopoverClose asChild>
-            <button
-              type="button"
-              className="cursor-pointer text-sm text-gray-500 hover:text-gray-700"
-            >
-              닫기
-            </button>
-          </PopoverClose>
-        </header>
-
-        {isLoading && (
-          <div className="flex h-[200px] items-center justify-center bg-white px-6 py-12 text-sm text-gray-500">
-            <p>알림을 불러오는 중..</p>
-          </div>
-        )}
-
-        {error && (
-          <div className="flex h-[200px] items-center justify-center bg-white px-6 py-12 text-sm text-gray-500">
-            <p>알림을 불러오는데 실패했습니다.</p>
-          </div>
-        )}
-
-        {!isLoading && !error && hasNotifications && (
-          <ul className="max-h-[320px] overflow-y-auto bg-white">
-            {notifications.map((item) => (
-              <li
-                key={item.id}
-                className={cn(
-                  'flex cursor-pointer items-start justify-between border-b px-6 py-4 transition-colors',
-                  'hover:bg-gray-100'
-                )}
-                onClick={() => handleNotificationClick(item)}
+        <PopoverContent className="mr-4 max-w-80 overflow-hidden p-0">
+          <header className="flex items-center justify-between border-b px-6 py-4">
+            <h2 className="text-lg font-semibold">알림</h2>
+            <PopoverClose asChild>
+              <button
+                type="button"
+                className="cursor-pointer text-sm text-gray-500 hover:text-gray-700"
               >
-                <div className="flex-1">
-                  <p className="text-text-sub2 text-xs font-semibold">
-                    {item.categoryKorean}
-                  </p>
-                  <p
-                    className={`mt-1 text-sm leading-relaxed hover:underline ${item.isRead ? 'font-body2-normal text-text-sub2' : 'font-body2-heading'}`}
-                  >
-                    {item.message}
-                  </p>
-                </div>
-                <div className="ml-3 flex flex-col items-end">
-                  <span className="text-xs text-gray-400">
-                    {item.relativeTime}
-                  </span>
-                  <button
-                    type="button"
-                    className="cursor-pointer p-1 text-gray-300 hover:text-gray-500"
-                    aria-label="알림 삭제"
-                    onClick={(event) => handleDelete(item.id, event)}
-                  >
-                    🗑️
-                  </button>
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
+                닫기
+              </button>
+            </PopoverClose>
+          </header>
 
-        {!isLoading && !error && !hasNotifications && (
-          <div className="flex h-[200px] items-center justify-center bg-white px-6 py-12 text-sm text-gray-500">
-            <p>최근 90일 동안 받은 알림이 없어요.</p>
-          </div>
-        )}
+          {isLoading && (
+            <div className="flex h-50 items-center justify-center bg-white px-6 py-12 text-sm text-gray-500">
+              <p>알림을 불러오는 중..</p>
+            </div>
+          )}
 
-        <footer className="flex items-center justify-between border-t bg-gray-900 px-6 py-4 text-sm text-white">
-          <div>
+          {error && (
+            <div className="flex h-50 items-center justify-center bg-white px-6 py-12 text-sm text-gray-500">
+              <p>알림을 불러오는데 실패했습니다.</p>
+            </div>
+          )}
+
+          {!isLoading && !error && hasNotifications && (
+            <ul className="max-h-80 overflow-y-auto bg-white">
+              {notifications.map((item) => (
+                <li
+                  key={item.id}
+                  className={cn(
+                    'flex cursor-pointer items-start justify-between border-b px-6 py-4 transition-colors',
+                    'hover:bg-gray-100'
+                  )}
+                  onClick={() => handleNotificationClick(item)}
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="text-text-sub2 text-xs font-semibold">
+                      {item.categoryKorean}
+                    </p>
+                    <p
+                      className={`mt-1 truncate text-sm leading-relaxed hover:underline ${item.isRead ? 'font-body2-normal text-text-sub2' : 'font-body2-heading'}`}
+                    >
+                      {item.message}
+                    </p>
+                  </div>
+                  <div className="ml-3 flex flex-col items-end">
+                    <span className="text-xs text-gray-400">
+                      {item.relativeTime}
+                    </span>
+                    <button
+                      type="button"
+                      className="cursor-pointer p-1 text-gray-300 hover:text-gray-500"
+                      aria-label="알림 삭제"
+                      onClick={(event) => handleDelete(item.id, event)}
+                    >
+                      🗑️
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {!isLoading && !error && !hasNotifications && (
+            <div className="flex h-50 items-center justify-center bg-white px-6 py-12 text-sm text-gray-500">
+              <p>최근 90일 동안 받은 알림이 없어요.</p>
+            </div>
+          )}
+
+          <footer className="flex items-center justify-between border-t bg-gray-900 px-6 py-4 text-sm text-white">
+            <div>
+              <button
+                type="button"
+                className="cursor-pointer hover:underline"
+                onClick={() => {
+                  dispatch({
+                    type: 'OPEN',
+                    scope: 'notification',
+                    kind: 'delete',
+                  });
+                  setIsDialogOpen(true);
+                }}
+              >
+                전체 삭제
+              </button>
+              <span aria-hidden> | </span>
+              <button
+                type="button"
+                className="cursor-pointer hover:underline"
+                onClick={handleMarkAllRead}
+              >
+                전체 읽음
+              </button>
+            </div>
             <button
               type="button"
-              className="cursor-pointer hover:underline"
-              onClick={handleDeleteAll}
+              className="flex cursor-pointer items-center gap-2 hover:underline"
+              aria-label="알림 설정"
             >
-              전체 삭제
+              ⚙️ 알림 설정
             </button>
-            <span aria-hidden> | </span>
-            <button
-              type="button"
-              className="cursor-pointer hover:underline"
-              onClick={handleMarkAllRead}
-            >
-              전체 읽음
-            </button>
-          </div>
-          <button
-            type="button"
-            className="flex cursor-pointer items-center gap-2 hover:underline"
-            aria-label="알림 설정"
-          >
-            ⚙️ 알림 설정
-          </button>
-        </footer>
-      </PopoverContent>
-    </Popover>
+          </footer>
+        </PopoverContent>
+      </Popover>
+
+      {dialog.status === 'open' && dialog.kind === 'delete' && (
+        <ConfirmDialog
+          variant="delete"
+          open={isDialogOpen}
+          dispatch={dispatch}
+          onConfirm={handleDeleteAll}
+          emphasis="none"
+          title="전체 알림을 삭제하시겠습니까?"
+          description="삭제된 알림은 복구할 수 없습니다."
+        />
+      )}
+
+      {dialog.status === 'open' && dialog.kind === 'onConfirm' && (
+        <ConfirmDialog
+          variant="confirm"
+          open={isDialogOpen}
+          dispatch={dispatch}
+          onConfirm={() => setIsDialogOpen(false)}
+          title="전체 알림이 삭제되었습니다."
+        />
+      )}
+    </>
   );
 }

--- a/src/features/notifications/components/notification-popover.tsx
+++ b/src/features/notifications/components/notification-popover.tsx
@@ -39,7 +39,8 @@ export function NotificationPopover() {
 
   const notifications = data ?? [];
   const hasNotifications = notifications.length > 0;
-  const unreadCount = unread?.length ?? 0;
+  const unreadNotifications = unread ?? [];
+  const hasUnreadNotifications = unreadNotifications.length > 0;
 
   const [dialog, dispatch] = useReducer(dialogReducer, initialDialogState);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -62,7 +63,7 @@ export function NotificationPopover() {
 
   // 전체 읽음 처리
   const handleMarkAllRead = () => {
-    if (!unreadCount) return;
+    if (!hasUnreadNotifications) return;
 
     const unreadIds = unread?.map((n) => n.id) ?? [];
     markAsRead.mutate(unreadIds);
@@ -86,24 +87,25 @@ export function NotificationPopover() {
   };
 
   return (
-    <Popover
-      open={isOpen}
-      onOpenChange={setIsOpen}
-    >
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className="relative flex size-6 cursor-pointer items-center justify-center outline-none"
-          aria-label="알림 확인"
-          onClick={() => {
-            // GNB 알림 아이콘 클릭 이벤트 전송
-            trackGnbAlarmClick(session?.role ?? null);
-          }}
-        >
-          <NotificationIcon hasNotifications={hasNotifications} />
-          <span className="sr-only">알림</span>
-        </button>
-      </PopoverTrigger>
+    <>
+      <Popover
+        open={isOpen}
+        onOpenChange={setIsOpen}
+      >
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="relative flex size-6 cursor-pointer items-center justify-center outline-none"
+            aria-label="알림 확인"
+            onClick={() => {
+              // GNB 알림 아이콘 클릭 이벤트 전송
+              trackGnbAlarmClick(session?.role ?? null);
+            }}
+          >
+            <NotificationIcon hasNotifications={hasUnreadNotifications} />
+            <span className="sr-only">알림</span>
+          </button>
+        </PopoverTrigger>
 
         <PopoverContent className="mr-4 max-w-80 overflow-hidden p-0">
           <header className="flex items-center justify-between border-b px-6 py-4">

--- a/src/features/notifications/hooks/use-notifications.ts
+++ b/src/features/notifications/hooks/use-notifications.ts
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 const ONE_MINUTE = 60 * 1000;
 
-// Query: 알림 목록 조회
+// 전체 알림 목록 조회
 // TODO SSE 전환 예정
 export const useNotifications = () =>
   useQuery({
@@ -15,6 +15,18 @@ export const useNotifications = () =>
     refetchOnWindowFocus: true,
   });
 
+// 미확인 알림 조회
+export const useUnreadNotifications = () => {
+  return useQuery({
+    queryKey: notificationKeys.unread(),
+    queryFn: notificationsApi.getUnread,
+    staleTime: ONE_MINUTE,
+    refetchInterval: ONE_MINUTE,
+    refetchOnWindowFocus: true,
+  });
+};
+
+// 알림 읽음 처리
 export const useMarkAsRead = () => {
   const queryClient = useQueryClient();
 
@@ -29,6 +41,7 @@ export const useMarkAsRead = () => {
   });
 };
 
+// 알림 삭제
 export const useDeleteNotifications = () => {
   const queryClient = useQueryClient();
 

--- a/src/features/notifications/hooks/use-notifications.ts
+++ b/src/features/notifications/hooks/use-notifications.ts
@@ -16,15 +16,14 @@ export const useNotifications = () =>
   });
 
 // 미확인 알림 조회
-export const useUnreadNotifications = () => {
-  return useQuery({
+export const useUnreadNotifications = () =>
+  useQuery({
     queryKey: notificationKeys.unread(),
     queryFn: notificationsApi.getUnread,
     staleTime: ONE_MINUTE,
     refetchInterval: ONE_MINUTE,
     refetchOnWindowFocus: true,
   });
-};
 
 // 알림 읽음 처리
 export const useMarkAsRead = () => {

--- a/src/features/notifications/hooks/use-notifications.ts
+++ b/src/features/notifications/hooks/use-notifications.ts
@@ -1,6 +1,6 @@
 import { notificationKeys } from '@/entities/notification';
 import { notificationsApi } from '@/features/notifications/api/notifications.api';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 const FIVE_MINUTES = 1000 * 60 * 5;
 
@@ -12,3 +12,17 @@ export const useNotifications = () =>
     staleTime: FIVE_MINUTES,
     refetchOnWindowFocus: true,
   });
+
+export const useMarkAsRead = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (notificationIds: number[]) =>
+      notificationsApi.markAsRead(notificationIds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: notificationKeys.all,
+      });
+    },
+  });
+};

--- a/src/features/notifications/hooks/use-notifications.ts
+++ b/src/features/notifications/hooks/use-notifications.ts
@@ -26,3 +26,17 @@ export const useMarkAsRead = () => {
     },
   });
 };
+
+export const useDeleteNotifications = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (notificationIds: number[]) =>
+      notificationsApi.delete(notificationIds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: notificationKeys.all,
+      });
+    },
+  });
+};

--- a/src/features/notifications/hooks/use-notifications.ts
+++ b/src/features/notifications/hooks/use-notifications.ts
@@ -2,14 +2,16 @@ import { notificationKeys } from '@/entities/notification';
 import { notificationsApi } from '@/features/notifications/api/notifications.api';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-const FIVE_MINUTES = 1000 * 60 * 5;
+const ONE_MINUTE = 60 * 1000;
 
 // Query: 알림 목록 조회
+// TODO SSE 전환 예정
 export const useNotifications = () =>
   useQuery({
     queryKey: notificationKeys.list(),
     queryFn: notificationsApi.getList,
-    staleTime: FIVE_MINUTES,
+    staleTime: ONE_MINUTE,
+    refetchInterval: ONE_MINUTE,
     refetchOnWindowFocus: true,
   });
 

--- a/src/layout/header.tsx
+++ b/src/layout/header.tsx
@@ -26,7 +26,7 @@ export const Header = () => {
   const { logout } = useAuth();
   const handleLogout = async () => {
     logout();
-    
+
     // GNB 로그아웃 클릭 이벤트 전송
     trackGnbLogoutClick(session?.role ?? null);
   };
@@ -111,18 +111,6 @@ export const Header = () => {
         </div>
         {session && (
           <div className="desktop:gap-4 flex items-center gap-1">
-            {/* <Image
-              src={'/img_header_bell.svg'}
-              alt="알림 벨 아이콘"
-              width={24}
-              height={24}
-              className="mr-8 cursor-pointer"
-              onClick={() => {
-                // GNB 알림 아이콘 클릭 이벤트 전송
-                trackGnbAlarmClick(session?.role ?? null);
-              }}
-            />
-            /> */}
             <NotificationPopover />
 
             <DropdownMenu>
@@ -148,9 +136,6 @@ export const Header = () => {
               </DropdownMenu.Content>
             </DropdownMenu>
 
-            {/* <p className="desktop:flex hidden items-center gap-2 text-[14px] font-[600] text-white">
-              {session.nickname}
-            </p> */}
             {session?.role && (
               <div className="desktop:flex hidden items-center rounded-[40px] border px-2 py-[2px] text-[12px] font-[400px] text-[#ffffff]">
                 {roleMetaMap[session.role]?.label}

--- a/src/shared/components/dialog/model/types.ts
+++ b/src/shared/components/dialog/model/types.ts
@@ -1,4 +1,10 @@
-export type DialogScope = 'group' | 'studyroom' | 'note' | 'invite' | 'qna';
+export type DialogScope =
+  | 'group'
+  | 'studyroom'
+  | 'note'
+  | 'invite'
+  | 'qna'
+  | 'notification';
 
 export type DialogKind =
   | 'rename'

--- a/src/shared/components/dialog/ui/confirm-dialog.tsx
+++ b/src/shared/components/dialog/ui/confirm-dialog.tsx
@@ -99,8 +99,6 @@ export const ConfirmDialog = ({
             variant={variant === 'delete' ? 'secondary' : 'secondary'}
             onClick={() => {
               onConfirm?.();
-              // 확인 후 닫기를 호출부에서 제어하려면 이 줄 제거
-              close();
             }}
             disabled={pending}
           >

--- a/src/shared/components/ui/popover.tsx
+++ b/src/shared/components/ui/popover.tsx
@@ -18,7 +18,7 @@ const PopoverContent = forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 w-[360px] rounded-2xl bg-white text-gray-900 shadow-lg ring-1 ring-black/5 outline-none',
+        'z-50 min-w-90 rounded-2xl bg-white text-gray-900 shadow-lg ring-1 ring-black/5 outline-none',
         className
       )}
       {...props}


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항

### 백엔드 스펙 변경 대응
- 응답 구조 변경: `type` → `category`
- 카테고리 추가: `SYSTEM`, `HOMEWORK`, `TEACHING_NOTE`, `STUDY_ROOM`, `QNA`
- Domain Schema에서 카테고리별 한글 매핑 및 라우팅 처리

### 알림 읽음 처리
- **개별 읽음** : 알림 클릭 시 자동 읽음 처리 및 관련 페이지로 이동
- **전체 읽음** : 미확인 알림 조회 → 일괄 읽음 처리
  - 무한스크롤 대응 : 화면 밖 미확인 알림도 처리

### 알림 삭제
- **개별 삭제** : 휴지통 아이콘 클릭 시 개별 알림 삭제
- **전체 삭제** : ConfirmDialog로 확인 후 일괄 삭제

### 페이지 이동
- 알림 클릭 시 카테고리별 페이지 이동
- Domain Schema에서 `targetUrl` 자동 생성
- 구현 완료: 
  - `TEACHING_NOTE`: `/study-rooms/1/note/${targetId}`
  - `STUDY_ROOM`: `/study-rooms/${targetId}/note`
- 보류: `HOMEWORK`, `QNA`

### 기타 개선
- Popover 열릴 때 자동 refetch로 최신 데이터 보장
  
## 이슈
- ConfirmDialog: `shared` 컴포넌트 사용 중
  - `TODO: 공용 컴포넌트 분리 예정`라는 주석이 달려있어 공유드립니다.
- 라우팅 임시 처리: 수업노트 URL에 임의의 studyRoomId(1) 사용
- 카테고리 미구현: HOMEWORK, QNA 페이지 이동 보류

## TODO
- SSE 실시간 알림

## 📷 스크린샷 or 코드 (선택사항)
<img width="567" height="640" alt="image" src="https://github.com/user-attachments/assets/91a93175-4d4e-49f7-8879-10c9a72b75bb" />

## 📚 참고 자료
- [알림 TBD](https://www.notion.so/gaan/MS3-TBD-294fbb391d7980dfbb7bc2507f76a85d?source=copy_link)
- [알림 API 명세서](https://www.notion.so/gaan/1fbfbb391d7980fc89a0ee13f69db55e?v=1fbfbb391d7981ae820f000c322f3326&source=copy_link)