### PR TITLE
BTS 366 : 카카오 소셜로그인 프로필 완성 후 세션 갱신

### DIFF
--- a/src/features/auth/components/social-login-button.tsx
+++ b/src/features/auth/components/social-login-button.tsx
@@ -1,14 +1,24 @@
 'use client';
 
 import Image from 'next/image';
+import { useSearchParams } from 'next/navigation';
 
 import { env, serverEnv } from '@/shared/constants/api';
 
 export default function SocialLoginButton() {
+  const searchParams = useSearchParams();
+  const error = searchParams.get('error');
+
   const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${env.kakaoClientId}&redirect_uri=${serverEnv.backendApiUrl}/auth/kakao/callback&response_type=code`;
 
   return (
-    <div className="mt-10 flex justify-center">
+    <div className="mt-10 flex flex-col items-center">
+      {error === 'kakao_failed' && (
+        <div className="text-system-warning mb-4">
+          카카오 로그인에 실패했습니다. 다시 시도해주세요.
+        </div>
+      )}
+
       <a href={kakaoAuthUrl}>
         <Image
           src="/auth/kakao_login_large_wide.png"

--- a/src/features/auth/components/social-select-role.tsx
+++ b/src/features/auth/components/social-select-role.tsx
@@ -7,11 +7,13 @@ import { useRouter } from 'next/navigation';
 import { ProfileForm } from '@/features/auth/components/profile-form';
 import { SocialRegisterForm } from '@/features/auth/schemas/social-register';
 import { useUpdateProfile } from '@/features/auth/services/query';
+import { useSession } from '@/providers';
 import { Form } from '@/shared/components/ui';
 import { zodResolver } from '@hookform/resolvers/zod';
 
 export const SocialSelectRole = () => {
   const router = useRouter();
+  const session = useSession();
   const { mutate: updateProfile, isPending } = useUpdateProfile();
 
   const form = useForm<SocialRegisterForm>({
@@ -25,7 +27,8 @@ export const SocialSelectRole = () => {
 
   const handleSubmit = form.handleSubmit(async (data) => {
     updateProfile(data, {
-      onSuccess: () => {
+      onSuccess: async () => {
+        await session.refresh();
         router.push('/dashboard');
       },
       onError: () => {

--- a/src/shared/api/http/interceptors.ts
+++ b/src/shared/api/http/interceptors.ts
@@ -19,8 +19,12 @@ function isForbidden(e: AxiosError) {
 }
 
 function isProfileIncomplete(e: AxiosError) {
+  const message = getMessage(e);
+
   return (
-    getStatus(e) === 403 && getMessage(e) === 'PROFILE_COMPLETION_REQUIRED'
+    getStatus(e) === 403 &&
+    (message === 'PROFILE_COMPLETION_REQUIRED' ||
+      message?.includes('프로필 완성'))
   );
 }
 

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -21,7 +21,16 @@ beforeEach(() => {
 beforeAll(() => {
   server.listen();
 
-  vi.mock('next/navigation', () => import('next-router-mock'));
+  vi.mock('next/navigation', async () => {
+    const actual = await vi.importActual('next-router-mock');
+
+    return {
+      ...actual,
+      useSearchParams: vi.fn(() => ({
+        get: vi.fn(() => null),
+      })),
+    };
+  });
 });
 
 afterEach(() => server.resetHandlers());


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 린트 에러가 없습니다.
- [ ] 코드가 올바르게 포맷팅되었습니다.
- [ ] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
- 카카오 소셜 로그인 프로필 완성 후 세션 갱신
  - 프로필 업데이트 성공 후 session.refresh() 호출
- 카카오 로그인 실패 시 에러 메시지 표시
  
## 🧐 관련 이슈
<!--
- 관련된 이슈 번호를 적어주세요. (ex. `Closes #123`, `Fixes #456`) 
-->

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->

## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
