### PR TITLE
BTS 373 : 프로필 조회

### DIFF
--- a/src/entities/profile/infrastructure/profile.keys.ts
+++ b/src/entities/profile/infrastructure/profile.keys.ts
@@ -1,4 +1,4 @@
 export const profileKeys = {
   all: ['profile'] as const,
-  myProfile: (userId?: string) => [...profileKeys.all, 'my', userId] as const,
+  profile: (memberId?: string) => [...profileKeys.all, memberId] as const,
 };

--- a/src/entities/profile/infrastructure/profile.repository.ts
+++ b/src/entities/profile/infrastructure/profile.repository.ts
@@ -6,11 +6,12 @@ import { CommonResponse } from '@/types';
 import { adapters } from './profile.adapters';
 
 /* ─────────────────────────────────────────────────────
- * [Read] 내 프로필 조회
+ * [Read] 프로필 조회
  * ────────────────────────────────────────────────────*/
-const getMyProfile = async (): Promise<FrontendProfile> => {
-  const response =
-    await api.private.get<CommonResponse<ProfileDTO>>('/members/profile');
+const getProfile = async (memberId: string): Promise<FrontendProfile> => {
+  const response = await api.public.get<CommonResponse<ProfileDTO>>(
+    `/public/members/profile/${memberId}`
+  );
 
   const validateResponse = adapters.fromApi.parse(response);
 
@@ -19,6 +20,6 @@ const getMyProfile = async (): Promise<FrontendProfile> => {
 
 export const repository = {
   profile: {
-    getMyProfile,
+    getProfile,
   },
 };

--- a/src/features/profile/api/profile.api.ts
+++ b/src/features/profile/api/profile.api.ts
@@ -2,8 +2,8 @@ import { repository } from '@/entities/profile';
 
 export const profileApi = {
   /**
-   * 내 프로필 조회
+   * 프로필 조회
    * @returns FrontendProfile
    */
-  getMyProfile: () => repository.profile.getMyProfile(),
+  getProfile: (memberId: string) => repository.profile.getProfile(memberId),
 };

--- a/src/features/profile/hooks/use-profile.ts
+++ b/src/features/profile/hooks/use-profile.ts
@@ -2,12 +2,12 @@ import { profileKeys } from '@/entities/profile';
 import { profileApi } from '@/features/profile/api/profile.api';
 import { useQuery } from '@tanstack/react-query';
 
-// 내 프로필 조회
-export const useMyProfile = (userId?: string) =>
+// 프로필 조회
+export const useProfile = (memberId?: string) =>
   useQuery({
-    queryKey: profileKeys.myProfile(userId),
-    queryFn: profileApi.getMyProfile,
+    queryKey: profileKeys.profile(memberId),
+    queryFn: () => profileApi.getProfile(memberId!),
     staleTime: Infinity,
     gcTime: 30 * 60 * 1000,
-    enabled: !!userId,
+    enabled: !!memberId,
   });


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
- getMyProfile -> getProfile로 변경하여 memberId 기반 조회로 통일
- api.private -> api.public 변경 (로그인 불필요한 public API)
- endpoint: `/public/members/profile/{memberId}`
- viewer 모드에서도 실제 API 데이터 조회 및 렌더링
- profileData 필드 기반 role 추론 로직 추가

## 📷 스크린샷 or 코드 (선택사항)
마이페이지:
<img width="1552" height="935" alt="image" src="https://github.com/user-attachments/assets/66a87f2c-bfd6-4ac2-9786-d65c641eff84" />
프로필:
<img width="1552" height="935" alt="image" src="https://github.com/user-attachments/assets/0ad7d478-2a79-4315-8d70-2e3e81aea73a" />

## 📚 참고 자료
[API 명세서](https://gaan.notion.site/api-public-members-profile-memberId-2e1fbb391d7980939c2ad3a0c3c34a96?source=copy_link)
