### PR TITLE
fix: 스터디룸 상세 정보 및 초대 디버깅

### DIFF
--- a/src/app/(private)/study-rooms/[id]/invite-member/page.tsx
+++ b/src/app/(private)/study-rooms/[id]/invite-member/page.tsx
@@ -44,7 +44,7 @@ const InviteMemberPage = () => {
           <InvitationField
             labelledById="invite-label"
             invitation={invitation}
-            placeholder="초대할 학생을 검색후 선택해 주세요."
+            placeholder="초대할 학생을 검색 후 선택해 주세요."
           />
           <aside
             role="note"

--- a/src/app/(private)/study-rooms/[id]/layout.tsx
+++ b/src/app/(private)/study-rooms/[id]/layout.tsx
@@ -81,7 +81,7 @@ const StudyNoteLayout = ({ children }: LayoutProps) => {
             onSelectGroup={setSelectedGroupId}
           />
         </ColumnLayout.Left>
-        <ColumnLayout.Right className="desktop:max-w-[740px] flex h-[400px] flex-col gap-3 rounded-[12px] px-8">
+        <ColumnLayout.Right className="desktop:max-w-[740px] desktop:px-8 flex h-[400px] flex-col gap-3 rounded-[12px]">
           <div>
             <StudyNoteTab
               mode={role}

--- a/src/features/profile/components/profile-layout.tsx
+++ b/src/features/profile/components/profile-layout.tsx
@@ -50,7 +50,7 @@ export default function ProfileLayout({
           />
         </div>
       </ColumnLayout.Left>
-      <ColumnLayout.Right className="desktop:max-w-[740px] px-8">
+      <ColumnLayout.Right className="desktop:max-w-[740px] desktop:px-8">
         <div className="flex flex-col gap-3">{sections}</div>
       </ColumnLayout.Right>
     </>

--- a/src/features/study-notes/api/note.api.base.ts
+++ b/src/features/study-notes/api/note.api.base.ts
@@ -21,9 +21,11 @@ export interface NotesBaseApi<TList> {
 }
 
 export const createNotesBaseApi = <TList>(role: Role): NotesBaseApi<TList> => {
-  // BFF에서 ROLE_* → teacher/student 변환 처리
+  // BFF에서 ROLE_* → teacher/student 변환 처리하지 않고 직접 처리하도록 수정
+  const rolePath = role === 'ROLE_TEACHER' ? 'teacher' : 'student';
+
   const roomPath = (studyRoomId: number) =>
-    `/${role}/study-rooms/${studyRoomId}`;
+    `/${rolePath}/study-rooms/${studyRoomId}`;
 
   return {
     async getNotes({ studyRoomId, pageable }) {

--- a/src/features/study-notes/components/study-note-tab.tsx
+++ b/src/features/study-notes/components/study-note-tab.tsx
@@ -19,7 +19,7 @@ const TABS_CONFIG = [
 ];
 
 const baseCls =
-  'relative flex h-[55px] min-w-[150px] items-center justify-center gap-2 rounded-t-[12px] border px-5 text-lg transition-colors';
+  'relative flex h-[55px] desktop:min-w-[150px] items-center justify-center gap-2 rounded-t-[12px] border px-5 text-lg transition-colors';
 
 export const StudyNoteTab = ({ studyRoomId, mode, path }: Props) => {
   return (

--- a/src/features/study-rooms/api/room.api.base.ts
+++ b/src/features/study-rooms/api/room.api.base.ts
@@ -33,6 +33,7 @@ export interface TeacherStudyRoomRequests {
 
 export interface StudentStudyRoomRequests {
   getStudyRooms(): Promise<StudentStudyRoom[]>;
+  getStudyRoomDetail(studyRoomId: number): Promise<StudyRoomDetail>;
   getStudentStudyNoteGroup(args: GroupApiArgs): Promise<GroupListResponse>;
   acceptInvitation(
     invitationId: number | string

--- a/src/features/study-rooms/api/room.api.base.ts
+++ b/src/features/study-rooms/api/room.api.base.ts
@@ -1,5 +1,5 @@
+import { Invitee } from '@/features/study-rooms/hooks/useInvitationController';
 import type {
-  Invitation,
   MemberInvitation,
   SearchInvitationPayload,
   StudentStudyRoom,
@@ -26,7 +26,7 @@ export interface TeacherStudyRoomRequests {
       studyRoomId: number;
       emails: string[];
     }): Promise<MemberInvitation>;
-    search(args: SearchInvitationPayload): Promise<Invitation>;
+    search(args: SearchInvitationPayload): Promise<Invitee[]>;
   };
   getStudyNoteGroup(args: GroupApiArgs): Promise<GroupListResponse>;
 }
@@ -51,7 +51,7 @@ export interface StudyRoomRequests {
       studyRoomId: number;
       emails: string[];
     }): Promise<MemberInvitation>;
-    search(args: SearchInvitationPayload): Promise<Invitation>;
+    search(args: SearchInvitationPayload): Promise<Invitee[]>;
   };
   getStudyNoteGroup(args: GroupApiArgs): Promise<GroupListResponse>;
 

--- a/src/features/study-rooms/api/room.api.student.ts
+++ b/src/features/study-rooms/api/room.api.student.ts
@@ -2,6 +2,7 @@ import {
   StudentStudyRoom,
   StudyNoteGroup,
   StudyRoomClient,
+  StudyRoomDetail,
 } from '@/features/study-rooms';
 import {
   InvitationAcceptResponse,
@@ -23,6 +24,16 @@ export const createStudentStudyRoomApi = (
     return response.data;
   };
 
+  // 스터디룸 상세 조회
+  const getStudyRoomDetail = async (
+    studyRoomId: number
+  ): Promise<StudyRoomDetail> => {
+    const response = await base.client.get<CommonResponse<StudyRoomDetail>>(
+      `${base.studentBasePath}/${studyRoomId}`
+    );
+    return response.data;
+  };
+
   // 수업노트 그룹 조회
   const getStudentStudyNoteGroup = async (args: {
     studyRoomId: number;
@@ -30,10 +41,10 @@ export const createStudentStudyRoomApi = (
   }): Promise<PaginationData<StudyNoteGroup>> => {
     const response = await base.client.get<
       CommonResponse<PaginationData<StudyNoteGroup>>
-    >(
-      `${base.teacherBasePath}/${args.studyRoomId}/teaching-note-groups`, // API 경로가 /teacher로 되어 있어 그대로 사용
-      { params: args.pageable, paramsSerializer: { indexes: null } }
-    );
+    >(`${base.studentBasePath}/${args.studyRoomId}/teaching-note-groups`, {
+      params: args.pageable,
+      paramsSerializer: { indexes: null },
+    });
     return response.data;
   };
 
@@ -53,6 +64,7 @@ export const createStudentStudyRoomApi = (
 
   return {
     getStudyRooms,
+    getStudyRoomDetail,
     getStudentStudyNoteGroup,
     acceptInvitation,
   };

--- a/src/features/study-rooms/api/room.api.teacher.ts
+++ b/src/features/study-rooms/api/room.api.teacher.ts
@@ -66,7 +66,7 @@ export const createTeacherStudyRoomApi = (
   ): Promise<Invitation> => {
     const response = await base.client.get<ApiResponse<Invitation>>(
       `${base.teacherBasePath}/${args.studyRoomId}/search`,
-      { params: { email: args.email } }
+      { params: { keyword: args.keyword } }
     );
     return response.data;
   };

--- a/src/features/study-rooms/api/room.api.teacher.ts
+++ b/src/features/study-rooms/api/room.api.teacher.ts
@@ -3,11 +3,11 @@ import {
   TeacherStudyRoomRequests,
   createStudyRoomBaseApi,
 } from '@/features/study-rooms/api';
+import { Invitee } from '@/features/study-rooms/hooks/useInvitationController';
 import type { CommonResponse, Pageable, PaginationData } from '@/types/http';
 
 import type {
   ApiResponse,
-  Invitation,
   MemberInvitation,
   SearchInvitationPayload,
   StudyNoteGroup,
@@ -63,8 +63,8 @@ export const createTeacherStudyRoomApi = (
   // 초대할 사용자 검색
   const searchInvitation = async (
     args: SearchInvitationPayload
-  ): Promise<Invitation> => {
-    const response = await base.client.get<ApiResponse<Invitation>>(
+  ): Promise<Invitee[]> => {
+    const response = await base.client.get<ApiResponse<Invitee[]>>(
       `${base.teacherBasePath}/${args.studyRoomId}/search`,
       { params: { keyword: args.keyword } }
     );

--- a/src/features/study-rooms/api/room.query.keys.ts
+++ b/src/features/study-rooms/api/room.query.keys.ts
@@ -16,6 +16,6 @@ export const StudyRoomsGroupQueryKey = {
 // 학생 초대
 export const InvitationQueryKey = {
   all: ['invitations'] as const,
-  search: (studyRoomId: number, email: string) =>
-    ['invitations', 'search', studyRoomId, email] as const,
+  search: (studyRoomId: number, keyword: string) =>
+    ['invitations', 'search', studyRoomId, keyword] as const,
 };

--- a/src/features/study-rooms/api/room.query.options.student.ts
+++ b/src/features/study-rooms/api/room.query.options.student.ts
@@ -5,7 +5,7 @@ import {
 import { BaseQueryOptions, queryConfig } from '@/shared/lib/query';
 import { queryOptions } from '@tanstack/react-query';
 
-import type { StudentStudyRoom } from '../model/types';
+import type { StudentStudyRoom, StudyRoomDetail } from '../model/types';
 
 export type StudentStudyRoomQueryOptions = ReturnType<
   typeof createStudentStudyRoomQueryOptions
@@ -25,5 +25,13 @@ export const createStudentStudyRoomQueryOptions = (
       ...opt,
     });
 
-  return { studentList };
+  // 스터디룸 상세 조회
+  const studentDetail = (studyRoomId: number) =>
+    queryOptions<StudyRoomDetail>({
+      queryKey: StudyRoomsQueryKey.detail(studyRoomId),
+      queryFn: () => api.getStudyRoomDetail(studyRoomId),
+      ...opt,
+    });
+
+  return { studentList, studentDetail };
 };

--- a/src/features/study-rooms/api/room.query.options.teacher.ts
+++ b/src/features/study-rooms/api/room.query.options.teacher.ts
@@ -32,9 +32,9 @@ export const createTeacherStudyRoomQueryOptions = (
     });
 
   // 초대 검색 (이메일)
-  const searchInvitation = (args: { studyRoomId: number; email: string }) =>
+  const searchInvitation = (args: { studyRoomId: number; keyword: string }) =>
     queryOptions({
-      queryKey: InvitationQueryKey.search(args.studyRoomId, args.email),
+      queryKey: InvitationQueryKey.search(args.studyRoomId, args.keyword),
       queryFn: () => api.invitations.search(args),
       ...opt,
       staleTime: 10_000,

--- a/src/features/study-rooms/components/sidebar/header.tsx
+++ b/src/features/study-rooms/components/sidebar/header.tsx
@@ -10,48 +10,61 @@ import { DropdownMenu } from '@/shared/components/ui/dropdown-menu';
 export const StudyroomSidebarHeader = ({
   dispatch,
   studyRoomName,
+  teacherName,
   canManage,
 }: {
   dispatch: Dispatch<DialogAction>;
   studyRoomName?: string;
+  teacherName?: string;
   canManage: boolean;
 }) => {
   return (
     <>
-      <div className="flex items-start justify-between">
-        <p className="desktop:max-w-[260px] text-[28px] leading-tight font-bold">
-          {studyRoomName || '스터디룸'}
-        </p>
-        {canManage && (
-          <DropdownMenu>
-            <DropdownMenu.Trigger className="flex cursor-pointer items-center justify-center">
-              <Image
-                src="/studyroom/ic-kebab.png"
-                alt="kebab-menu"
-                width={48}
-                height={48}
-                className="cursor-pointer self-start rounded-[8px] border-none p-1 hover:bg-gray-100"
-              />
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content>
-              <DropdownMenu.Item
-                onClick={() =>
-                  dispatch({ type: 'OPEN', scope: 'studyroom', kind: 'rename' })
-                }
-              >
-                편집하기
-              </DropdownMenu.Item>
-              <DropdownMenu.Item
-                variant="danger"
-                onClick={() =>
-                  dispatch({ type: 'OPEN', scope: 'studyroom', kind: 'delete' })
-                }
-              >
-                삭제하기
-              </DropdownMenu.Item>
-            </DropdownMenu.Content>
-          </DropdownMenu>
-        )}
+      <div>
+        <div className="flex h-12 items-center justify-between">
+          <p className="desktop:max-w-[260px] truncate text-[28px] leading-tight font-bold">
+            {studyRoomName || '스터디룸'}
+          </p>
+          {canManage && (
+            <DropdownMenu>
+              <DropdownMenu.Trigger className="flex cursor-pointer items-center justify-center">
+                <Image
+                  src="/studyroom/ic-kebab.png"
+                  alt="kebab-menu"
+                  width={48}
+                  height={48}
+                  className="cursor-pointer self-start rounded-[8px] border-none p-1 hover:bg-gray-100"
+                />
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content>
+                <DropdownMenu.Item
+                  onClick={() =>
+                    dispatch({
+                      type: 'OPEN',
+                      scope: 'studyroom',
+                      kind: 'rename',
+                    })
+                  }
+                >
+                  편집하기
+                </DropdownMenu.Item>
+                <DropdownMenu.Item
+                  variant="danger"
+                  onClick={() =>
+                    dispatch({
+                      type: 'OPEN',
+                      scope: 'studyroom',
+                      kind: 'delete',
+                    })
+                  }
+                >
+                  삭제하기
+                </DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu>
+          )}
+        </div>
+        {!canManage && <p>{teacherName} 선생님</p>}
       </div>
       <Image
         src="/studyroom/profile.svg"

--- a/src/features/study-rooms/components/sidebar/header.tsx
+++ b/src/features/study-rooms/components/sidebar/header.tsx
@@ -10,9 +10,11 @@ import { DropdownMenu } from '@/shared/components/ui/dropdown-menu';
 export const StudyroomSidebarHeader = ({
   dispatch,
   studyRoomName,
+  canManage,
 }: {
   dispatch: Dispatch<DialogAction>;
   studyRoomName?: string;
+  canManage: boolean;
 }) => {
   return (
     <>
@@ -20,34 +22,36 @@ export const StudyroomSidebarHeader = ({
         <p className="desktop:max-w-[260px] text-[28px] leading-tight font-bold">
           {studyRoomName || '스터디룸'}
         </p>
-        <DropdownMenu>
-          <DropdownMenu.Trigger className="flex cursor-pointer items-center justify-center">
-            <Image
-              src="/studyroom/ic-kebab.png"
-              alt="kebab-menu"
-              width={48}
-              height={48}
-              className="cursor-pointer self-start rounded-[8px] border-none p-1 hover:bg-gray-100"
-            />
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Content>
-            <DropdownMenu.Item
-              onClick={() =>
-                dispatch({ type: 'OPEN', scope: 'studyroom', kind: 'rename' })
-              }
-            >
-              편집하기
-            </DropdownMenu.Item>
-            <DropdownMenu.Item
-              variant="danger"
-              onClick={() =>
-                dispatch({ type: 'OPEN', scope: 'studyroom', kind: 'delete' })
-              }
-            >
-              삭제하기
-            </DropdownMenu.Item>
-          </DropdownMenu.Content>
-        </DropdownMenu>
+        {canManage && (
+          <DropdownMenu>
+            <DropdownMenu.Trigger className="flex cursor-pointer items-center justify-center">
+              <Image
+                src="/studyroom/ic-kebab.png"
+                alt="kebab-menu"
+                width={48}
+                height={48}
+                className="cursor-pointer self-start rounded-[8px] border-none p-1 hover:bg-gray-100"
+              />
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+              <DropdownMenu.Item
+                onClick={() =>
+                  dispatch({ type: 'OPEN', scope: 'studyroom', kind: 'rename' })
+                }
+              >
+                편집하기
+              </DropdownMenu.Item>
+              <DropdownMenu.Item
+                variant="danger"
+                onClick={() =>
+                  dispatch({ type: 'OPEN', scope: 'studyroom', kind: 'delete' })
+                }
+              >
+                삭제하기
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu>
+        )}
       </div>
       <Image
         src="/studyroom/profile.svg"

--- a/src/features/study-rooms/components/sidebar/index.tsx
+++ b/src/features/study-rooms/components/sidebar/index.tsx
@@ -143,7 +143,7 @@ export const StudyroomSidebar = ({
           <InvitationDialog
             isOpen={true}
             title="스터디룸에 학생 초대"
-            placeholder="초대할 학생을 검색후 선택해 주세요."
+            placeholder="초대할 학생을 검색 후 선택해 주세요."
             studyRoomId={studyRoomId}
             onOpenChange={() => dispatch({ type: 'CLOSE' })}
           />

--- a/src/features/study-rooms/components/sidebar/index.tsx
+++ b/src/features/study-rooms/components/sidebar/index.tsx
@@ -152,6 +152,7 @@ export const StudyroomSidebar = ({
         <StudyroomSidebarHeader
           dispatch={dispatch}
           studyRoomName={studyRoomDetail?.name}
+          teacherName={studyRoomDetail?.teacherName}
           canManage={canManage}
         />
         <StudyStats

--- a/src/features/study-rooms/components/sidebar/index.tsx
+++ b/src/features/study-rooms/components/sidebar/index.tsx
@@ -41,6 +41,7 @@ export const StudyroomSidebar = ({
   const { role } = useRole();
   const { mutate: deleteStudyRoom } = useDeleteStudyRoom();
   const { mutate: updateRoomName } = useUpdateStudyRoom();
+
   // 스터디룸 상세 정보 조회 (선생님만)
   const { data: studyRoomDetail } = useTeacherStudyRoomDetailQuery(
     studyRoomId,
@@ -48,6 +49,9 @@ export const StudyroomSidebar = ({
       enabled: role === 'ROLE_TEACHER',
     }
   );
+
+  // 삭제, 수정, 학생 초대 등 관리 권한
+  const canManage = role === 'ROLE_TEACHER';
 
   // TODO: 스터디룸 이름 변경 API 연결
   const handleSubmitRoomRename = (name: string, others: StudyRoomDetail) => {
@@ -133,13 +137,14 @@ export const StudyroomSidebar = ({
         <StudyroomSidebarHeader
           dispatch={dispatch}
           studyRoomName={studyRoomDetail?.name}
+          canManage={canManage}
         />
         <StudyStats
           numberOfTeachingNote={studyRoomDetail?.numberOfTeachingNote}
           numberOfStudents={studyRoomDetail?.studentNames?.length}
           numberOfQuestion={studyRoomDetail?.numberOfQuestion}
         />
-        <StudentInvitation dispatch={dispatch} />
+        {canManage && <StudentInvitation dispatch={dispatch} />}
         {/* 수업노트 탭에서만 보이는 컴포넌트 */}
         {segment === 'note' && (
           <StudyroomGroups

--- a/src/features/study-rooms/components/sidebar/index.tsx
+++ b/src/features/study-rooms/components/sidebar/index.tsx
@@ -121,6 +121,7 @@ export const StudyroomSidebar = ({
             description="삭제된 스터디룸은 복구할 수 없습니다."
           />
         )}
+
       {dialog.status === 'open' &&
         dialog.kind === 'rename' &&
         dialog.scope === 'studyroom' &&

--- a/src/features/study-rooms/components/sidebar/index.tsx
+++ b/src/features/study-rooms/components/sidebar/index.tsx
@@ -171,10 +171,6 @@ export const StudyroomSidebar = ({
             handleSelectGroupId={onSelectGroup}
           />
         )}
-        {/* TODO: 마지막 활동 시간 추가 */}
-        <div className="font-body2-normal text-gray-scale-gray-60 flex items-end justify-end">
-          <p className="text-right">마지막 활동 3일전</p>
-        </div>
       </ColumnLayout.Left>
     </>
   );

--- a/src/features/study-rooms/components/sidebar/index.tsx
+++ b/src/features/study-rooms/components/sidebar/index.tsx
@@ -9,7 +9,10 @@ import { InputDialog } from '@/features/study-rooms/components/common/dialog/inp
 import { StudyroomGroups } from '@/features/study-rooms/components/sidebar/groups';
 import { InvitationDialog } from '@/features/study-rooms/components/student-invitation/InvitationDialog';
 import StudentInvitation from '@/features/study-rooms/components/student-invitation/StudentInvitation';
-import { useTeacherStudyRoomDetailQuery } from '@/features/study-rooms/hooks';
+import {
+  useStudentStudyRoomDetailQuery,
+  useTeacherStudyRoomDetailQuery,
+} from '@/features/study-rooms/hooks';
 import { ColumnLayout } from '@/layout/column-layout';
 import {
   dialogReducer,
@@ -42,13 +45,25 @@ export const StudyroomSidebar = ({
   const { mutate: deleteStudyRoom } = useDeleteStudyRoom();
   const { mutate: updateRoomName } = useUpdateStudyRoom();
 
-  // 스터디룸 상세 정보 조회 (선생님만)
-  const { data: studyRoomDetail } = useTeacherStudyRoomDetailQuery(
+  // 스터디룸 상세 정보 조회 (선생님)
+  const { data: teacherStudyRoomDetail } = useTeacherStudyRoomDetailQuery(
     studyRoomId,
     {
       enabled: role === 'ROLE_TEACHER',
     }
   );
+
+  // 스터디룸 상세 정보 조회 (학생)
+  const { data: studentStudyRoomDetail } = useStudentStudyRoomDetailQuery(
+    studyRoomId,
+    {
+      enabled: role === 'ROLE_STUDENT',
+    }
+  );
+
+  let studyRoomDetail: StudyRoomDetail | undefined;
+  if (role === 'ROLE_TEACHER') studyRoomDetail = teacherStudyRoomDetail;
+  if (role === 'ROLE_STUDENT') studyRoomDetail = studentStudyRoomDetail;
 
   // 삭제, 수정, 학생 초대 등 관리 권한
   const canManage = role === 'ROLE_TEACHER';
@@ -144,6 +159,8 @@ export const StudyroomSidebar = ({
           numberOfStudents={studyRoomDetail?.studentNames?.length}
           numberOfQuestion={studyRoomDetail?.numberOfQuestion}
         />
+
+        {/* 학생 초대 버튼 - 선생님만 노출 */}
         {canManage && <StudentInvitation dispatch={dispatch} />}
         {/* 수업노트 탭에서만 보이는 컴포넌트 */}
         {segment === 'note' && (

--- a/src/features/study-rooms/components/sidebar/status/index.tsx
+++ b/src/features/study-rooms/components/sidebar/status/index.tsx
@@ -9,26 +9,6 @@ export const StudyStats = ({
   numberOfStudents?: number;
   numberOfQuestion?: number;
 }) => {
-  // TODO: 매핑 방식으로 변경하려고 했으나 SVG 오류
-  // const studyIcons: { name: string; Icon: IconCmp; count: string }[] = [
-  //   {
-  //     name: '수업노트',
-  //     Icon: Icon.Notebook,
-  //     count: '999장',
-  //   },
-  //   {
-  //     name: '학생',
-  //     Icon: Icon.Person,
-  //     count: '999명',
-  //   },
-
-  //   {
-  //     name: '질문',
-  //     Icon: Icon.Question,
-  //     count: '999개',
-  //   },
-  // ];
-
   return (
     <ul className="flex items-center justify-between px-3 py-4">
       <li
@@ -53,7 +33,7 @@ export const StudyStats = ({
           학생
         </p>
         <p className="font-headline2-heading text-key-color-primary text-center">
-          {numberOfStudents != null ? `${numberOfStudents}명` : ''}
+          {numberOfStudents != null ? `${numberOfStudents}명` : '0명'}
         </p>
       </li>
       <li

--- a/src/features/study-rooms/components/student-invitation/InvitationSearchResult.tsx
+++ b/src/features/study-rooms/components/student-invitation/InvitationSearchResult.tsx
@@ -13,6 +13,11 @@ export const InvitationSearchResult = ({
 }: {
   invitation: InvitationController;
 }) => {
+  const studentResults =
+    invitation.searchResult?.filter((user) => user.role === 'ROLE_STUDENT') ||
+    [];
+  const hasResults = studentResults?.length > 0;
+
   return (
     <div
       id="invitation-search-panel"
@@ -26,16 +31,16 @@ export const InvitationSearchResult = ({
       >
         초대 대상 검색
       </h3>
-      <TextField>
+      <TextField className="flex justify-between">
         <TextField.Label className="sr-only">
-          초대 대상 이메일 검색
+          초대 대상 이름 또는 이메일 검색
         </TextField.Label>
         <TextField.Input
           autoFocus
           value={invitation.searchQuery}
           onChange={(e) => invitation.setSearchQuery(e.target.value)}
-          placeholder="초대할 사람의 이메일을 입력하세요."
-          aria-label="초대 대상 이메일 검색"
+          placeholder="이름 또는 이메일 입력 후 Enter 키를 눌러 검색하세요."
+          aria-label="초대 대상 이름 또는 이메일 검색"
           aria-controls="invitation-results"
           aria-expanded={!!invitation.searchResult}
           aria-autocomplete="list"
@@ -59,6 +64,7 @@ export const InvitationSearchResult = ({
             }
           }}
         />
+        <span className="place-self-center">↵</span>
       </TextField>
 
       <div
@@ -66,54 +72,68 @@ export const InvitationSearchResult = ({
         role="listbox"
         aria-label="검색 결과"
       >
-        {invitation.searchResult && (
-          <Button
-            onClick={invitation.addUser}
-            role="option"
-            aria-selected="false"
-            aria-describedby="invitation-result-0"
-            aria-label={`${invitation.searchResult?.inviteeName}, ${invitation.searchResult?.role}, ${invitation.searchResult?.connectedGuardianCount} — ${
-              invitation.searchResult?.canInvite ? '초대 가능' : '초대 완료'
-            }. 초대하기`}
-            variant="outlined"
-            className="hover:border-key-color-primary flex w-full cursor-pointer items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3 hover:bg-transparent active:bg-transparent"
-          >
-            <div className="flex items-center gap-3">
-              <Image
-                src={'/img_header_profile.svg'}
-                alt="프로필 사진"
-                width={48}
-                height={48}
-                className="rounded-full"
-              />
-
-              <div className="flex items-center gap-2">
-                <span className="font-medium text-gray-900">
-                  {invitation.searchResult?.inviteeName}
-                </span>
-                <span className="rounded-md border border-gray-300 px-1.5 py-[1px] text-sm text-gray-700">
-                  {invitation.searchResult?.role}
-                </span>
-                <span
-                  className="text-key-color-primary text-[10px] leading-[0]"
-                  aria-hidden="true"
+        {invitation.searchResult !== null &&
+          (hasResults
+            ? studentResults.map((user) => (
+                <Button
+                  key={user.inviteeId}
+                  onClick={() => invitation.addUser(user)}
+                  role="option"
+                  aria-selected="false"
+                  aria-describedby="invitation-result-0"
+                  aria-label={`${user.inviteeName}, ${user.role}, ${user.connectedGuardianCount} — ${
+                    user.canInvite ? '초대 가능' : '초대 완료'
+                  }. 초대하기`}
+                  variant="outlined"
+                  className="hover:border-key-color-primary flex h-fit w-full cursor-pointer items-center justify-between rounded-lg border border-gray-200 bg-white px-6 py-3 hover:bg-transparent active:bg-transparent"
+                  disabled={!user.canInvite}
                 >
-                  ●
-                </span>
-                <span className="text-system-warning text-sm">
-                  보호자 {invitation.searchResult?.connectedGuardianCount}
-                </span>
-              </div>
-            </div>
+                  <div className="flex items-center gap-3">
+                    <Image
+                      src={'/img_header_profile.svg'}
+                      alt="프로필 사진"
+                      width={48}
+                      height={48}
+                      className="rounded-full"
+                    />
 
-            <p
-              id="invitation-result-0-status"
-              className="text-md font-semibold text-gray-500"
-            >
-              {invitation.searchResult?.canInvite ? '초대 가능' : '초대 완료'}
-            </p>
-          </Button>
-        )}
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-gray-900">
+                          {user.inviteeName}
+                        </span>
+                        <span className="rounded-md border border-gray-300 px-1.5 py-[1px] text-sm text-gray-700">
+                          {user.role === 'ROLE_STUDENT' && '학생'}
+                        </span>
+                        <span
+                          className="text-key-color-primary text-[10px] leading-[0]"
+                          aria-hidden="true"
+                        >
+                          ●
+                        </span>
+                        <span className="text-system-warning text-sm">
+                          보호자 {user.connectedGuardianCount}
+                        </span>
+                      </div>
+                      <p className="text-text-sub2 text-start">
+                        {user.inviteeEmail}
+                      </p>
+                    </div>
+                  </div>
+
+                  <p
+                    id="invitation-result-0-status"
+                    className="text-md font-semibold text-gray-500"
+                  >
+                    {user.canInvite ? '초대 가능' : '초대 완료'}
+                  </p>
+                </Button>
+              ))
+            : invitation.searchQuery.trim().length > 0 && (
+                <div className="flex w-full items-center justify-center py-6 text-sm text-gray-500">
+                  검색 결과가 없습니다.
+                </div>
+              ))}
       </div>
     </div>
   );

--- a/src/features/study-rooms/components/student-invitation/InvitationSearchResult.tsx
+++ b/src/features/study-rooms/components/student-invitation/InvitationSearchResult.tsx
@@ -73,7 +73,7 @@ export const InvitationSearchResult = ({
             aria-selected="false"
             aria-describedby="invitation-result-0"
             aria-label={`${invitation.searchResult?.inviteeName}, ${invitation.searchResult?.role}, ${invitation.searchResult?.connectedGuardianCount} — ${
-              invitation.searchResult?.canInvite ? '초대 가능' : '이미 초대됨'
+              invitation.searchResult?.canInvite ? '초대 가능' : '초대 완료'
             }. 초대하기`}
             variant="outlined"
             className="hover:border-key-color-primary flex w-full cursor-pointer items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3 hover:bg-transparent active:bg-transparent"
@@ -110,7 +110,7 @@ export const InvitationSearchResult = ({
               id="invitation-result-0-status"
               className="text-md font-semibold text-gray-500"
             >
-              {invitation.searchResult?.canInvite ? '초대 가능' : '이미 초대됨'}
+              {invitation.searchResult?.canInvite ? '초대 가능' : '초대 완료'}
             </p>
           </Button>
         )}

--- a/src/features/study-rooms/hooks/index.ts
+++ b/src/features/study-rooms/hooks/index.ts
@@ -18,7 +18,8 @@ const studentHooks = createStudentStudyRoomHooks(studentStudyRoomApi);
 
 const teacherHooks = createTeacherStudyRoomHooks(teacherStudyRoomApi);
 
-export const { useStudentStudyRoomsQuery } = studentHooks;
+export const { useStudentStudyRoomsQuery, useStudentStudyRoomDetailQuery } =
+  studentHooks;
 
 export const {
   useTeacherStudyRoomsQuery,

--- a/src/features/study-rooms/hooks/room.query.hooks.student.ts
+++ b/src/features/study-rooms/hooks/room.query.hooks.student.ts
@@ -2,7 +2,7 @@ import {
   StudentStudyRoomRequests,
   createStudentStudyRoomQueryOptions,
 } from '@/features/study-rooms/api';
-import { BaseQueryOptions } from '@/shared/lib/query';
+import { BaseQueryOptions } from '@/shared/lib';
 import { useQuery } from '@tanstack/react-query';
 
 export const createStudentStudyRoomHooks = (
@@ -17,7 +17,19 @@ export const createStudentStudyRoomHooks = (
       ...qo.studentList(),
       enabled: options?.enabled ?? true,
     });
+
+  // 스터디룸 상세 조회
+  const useStudentStudyRoomDetailQuery = (
+    studyRoomId: number,
+    options?: { enabled?: boolean }
+  ) =>
+    useQuery({
+      ...qo.studentDetail(studyRoomId),
+      enabled: options?.enabled ?? true,
+    });
+
   return {
     useStudentStudyRoomsQuery,
+    useStudentStudyRoomDetailQuery,
   };
 };

--- a/src/features/study-rooms/hooks/room.query.hooks.teacher.ts
+++ b/src/features/study-rooms/hooks/room.query.hooks.teacher.ts
@@ -24,7 +24,7 @@ export const createTeacherStudyRoomHooks = (
       enabled: options?.enabled ?? true,
     });
 
-  // 스터디룸 상세 조회
+  // 스터디룸 상세 조회 (선생님)
   const useTeacherStudyRoomDetailQuery = (
     studyRoomId: number,
     options?: { enabled?: boolean }

--- a/src/features/study-rooms/hooks/room.query.hooks.teacher.ts
+++ b/src/features/study-rooms/hooks/room.query.hooks.teacher.ts
@@ -9,7 +9,7 @@ import type { StudyRoomFormValues } from '@/features/study-rooms/model';
 import { BaseQueryOptions } from '@/shared/lib/query';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-type SearchArgs = { studyRoomId: number; email: string; enabled?: boolean };
+type SearchArgs = { studyRoomId: number; keyword: string; enabled?: boolean };
 
 export const createTeacherStudyRoomHooks = (
   api: TeacherStudyRoomRequests,
@@ -34,14 +34,14 @@ export const createTeacherStudyRoomHooks = (
       enabled: options?.enabled ?? true,
     });
 
-  // 이메일 초대 검색
+  // 사용자 이름 초대 검색
   const useSearchInvitation = (args: SearchArgs) =>
     useQuery({
       ...qo.searchInvitation({
         studyRoomId: args.studyRoomId,
-        email: args.email,
+        keyword: args.keyword,
       }),
-      enabled: args.enabled ?? args.email.trim().length > 0,
+      enabled: false,
     });
 
   // 스터디룸 생성

--- a/src/features/study-rooms/hooks/useInvitationController.ts
+++ b/src/features/study-rooms/hooks/useInvitationController.ts
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useSearchInvitation } from '@/features/study-rooms';
 
@@ -35,22 +35,19 @@ export const useInvitationController = (
   studyRoomId: number
 ): InvitationController => {
   // TODO: 추후 리듀서로 리팩토링 예정
-  const [isSearch, setIsSearch] = React.useState(false);
+  const [isSearch, setIsSearch] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResult, setSearchResult] = useState<null | Invitee>(null);
   const [invitees, setInvitees] = useState<Map<string, Invitee>>(new Map());
-  const [shouldSearch, setShouldSearch] = useState(false);
 
-  const { data } = useSearchInvitation({
+  const { refetch, data } = useSearchInvitation({
     studyRoomId,
-    email: searchQuery,
-    enabled: shouldSearch && !!searchQuery.trim(),
+    keyword: searchQuery,
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (data) {
       setSearchResult(data);
-      setShouldSearch(false);
     }
   }, [data]);
 
@@ -58,13 +55,13 @@ export const useInvitationController = (
   const closeSearch = () => setIsSearch(false);
   const toggle = () => setIsSearch((prev: boolean) => !prev);
 
-  const search = (query?: string) => {
-    setSearchQuery(query ?? '');
-    setShouldSearch(true);
+  const search = async () => {
+    if (!searchQuery.trim()) return;
+    await refetch();
   };
 
   const addUser = () => {
-    if (!searchResult) return alert('사용자가 없어용');
+    if (!searchResult) return;
     setInvitees((prev) => {
       const next = new Map(prev);
       return next.set(searchResult.inviteeEmail, searchResult);

--- a/src/features/study-rooms/model/types.ts
+++ b/src/features/study-rooms/model/types.ts
@@ -96,7 +96,7 @@ export interface InvitationPayload {
 
 export interface SearchInvitationPayload {
   studyRoomId: number;
-  email: string;
+  keyword: string;
 }
 
 export interface DeleteStudyRoomPayload {


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
1. 학생 초대 변경된 api에 맞게 수정
  - 이메일 검색 -> 이메일, 이름 검색
  - 단일 응답 -> 배열
2. 학생 스터디룸 상세 조회 API 연동
3. 관리 권한 없는 역할에 삭제/수정/초대 UI 숨김 처리 (UX 개선)

## 📷 스크린샷 or 코드 (선택사항)
1. 학생 초대 변경된 api에 맞게 수정
<img width="2048" height="1234" alt="image" src="https://github.com/user-attachments/assets/6d2797e0-f7f9-47fa-bc8d-17db441e96e9" />

2. 학생 스터디룸 상세 조회 API 연동
<table>
<tbody>
<tr>
<td>
스터디룸 - 학생 수정 전:
<img width="432" height="928" alt="image" src="https://github.com/user-attachments/assets/f4589e3c-9903-40a7-8710-98bc693ffbfd" />  
</td>
<td>
스터디룸 - 학생 수정 후:
<img width="436" height="924" alt="image" src="https://github.com/user-attachments/assets/f7cc9895-a978-4c66-849b-16edf20b9c3e" />
</td>
</tr>
</tbody>
</table>

3. 관리 권한 없는 역할에 삭제/수정/초대 UI 숨김 처리 (UX 개선)
<table>
<tbody>
<tr>
<td>
스터디룸 - 선생님:
<img width="2048" height="1438" alt="image" src="https://github.com/user-attachments/assets/410da67a-6532-4c24-8d32-11e142922978" />
</td>
<td>
스터디룸 - 학생:
<img width="2048" height="1438" alt="image" src="https://github.com/user-attachments/assets/fd417425-b864-4067-b413-88985fc790de" />
</td>
</tr>
</tbody>
</table>

## 이슈
스터디룸에서 entities/ 계층이 사용되지 않는 것으로 보입니다.  
유지보수 측면에서 리팩토링이 필요할 것 같습니다.  
`src/entities/study-room/core/room.factory.ts`  
`src/entities/study-room/core/room.factory.ts`  
`src/entities/study-room/infrastructure/room.adapters.ts`  
`src/entities/study-room/infrastructure/room.dto.schema.ts`  
`src/entities/study-room/types/room.types.ts`  


## 📚 참고 자료
- https://api.dev.d-edu.site/swagger-ui/index.html#/study-room-controller/searchInviteesToStudyRoom
- https://api.dev.d-edu.site/swagger-ui/index.html#/study-room-controller/getStudentStudyRoom