### PR TITLE
fix: 설정페이지 제거 및 문의하기 버튼 클릭시 카톡채널 안내

### DIFF
--- a/src/app/(private)/dashboard/settings/page.tsx
+++ b/src/app/(private)/dashboard/settings/page.tsx
@@ -1,3 +1,0 @@
-export default function SettingsPage() {
-  return <main>설정</main>;
-}

--- a/src/features/dashboard/components/dashboard-sidebar.tsx
+++ b/src/features/dashboard/components/dashboard-sidebar.tsx
@@ -1,14 +1,13 @@
 'use client';
 
 import Image from 'next/image';
-import Link from 'next/link';
 
 import { useDashboardQuery } from '@/features/dashboard';
 import {
   useStudentStudyRoomsQuery,
   useTeacherStudyRoomsQuery,
 } from '@/features/study-rooms';
-import { HomeIcon, PlusIcon, SettingIcon } from '@/shared/components/icons';
+import { HomeIcon, PlusIcon } from '@/shared/components/icons';
 import { Sidebar } from '@/shared/components/sidebar';
 import { PRIVATE } from '@/shared/constants/route';
 import { useRole } from '@/shared/hooks/use-role';
@@ -78,14 +77,17 @@ export const DashboardSidebar = () => {
         </Sidebar.List>
       </Sidebar.ScrollArea>
 
-      <Sidebar.Item href={PRIVATE.DASHBOARD.SETTINGS}>
+      {/* 기능 추가 전까지 잠시 주석 (private -> dashboard 안에 있는 settings 페이지도 삭제 완) */}
+      {/* <Sidebar.Item href={PRIVATE.DASHBOARD.SETTINGS}>
         <SettingIcon />
         <Sidebar.Text>환경설정</Sidebar.Text>
-      </Sidebar.Item>
+      </Sidebar.Item> */}
 
       <div className="mt-auto flex justify-end p-4">
-        <Link
-          href={PRIVATE.DASHBOARD.INQUIRY}
+        <a
+          href={'https://pf.kakao.com/_LMcpn'}
+          target="_blank"
+          rel="noopener noreferrer"
           className="text-gray-scale-gray-50 hover:bg-gray-scale-gray-5 flex items-center gap-2 rounded-lg text-[14px] font-semibold"
         >
           <Sidebar.Text>디에듀에 문의하기</Sidebar.Text>
@@ -95,7 +97,7 @@ export const DashboardSidebar = () => {
             width={16}
             height={16}
           />
-        </Link>
+        </a>
       </div>
     </Sidebar>
   );


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 린트 에러가 없습니다.
- [ ] 코드가 올바르게 포맷팅되었습니다.
- [ ] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
1. 로그인 후 나오는 사이드 바에 있는 환경설정 버튼 현재는 환경설정 관련 기능이 없어 제거
2. 사이드 바 밑에 있는 디에듀에게 문의하기 버튼 클릭시 카카오 채널로 넘어가도록 링크 변
  
## 📷 스크린샷 or 코드 (선택사항)
<img width="266" height="783" alt="image" src="https://github.com/user-attachments/assets/de46e7fe-f005-4649-8589-1fc185068b51" />

