### PR TITLE
Feature/ms3/bts-362 [에디터] 과제, 질문 이미지 보이지 않는 현상 수정

### DIFF
--- a/src/features/homework/components/detail/student-homework-detail.tsx
+++ b/src/features/homework/components/detail/student-homework-detail.tsx
@@ -79,7 +79,11 @@ export const StudentHomeworkDetail = ({ studyRoomId, homeworkId }: Props) => {
         {/* 선생님이 낸 과제 */}
         {data.homework && (
           <StudentHomeworkContent
-            content={data.homework.content ?? '-'}
+            content={
+              data.homework.resolvedContent?.content ??
+              data.homework.content ??
+              '-'
+            }
             authorName={data.homework.teacherName ?? '-'}
             regDate={data.homework.modifiedAt ?? '-'}
           />
@@ -95,7 +99,11 @@ export const StudentHomeworkDetail = ({ studyRoomId, homeworkId }: Props) => {
               >
                 <StudentSubmissionContent
                   homeworkStudentId={item.data.id}
-                  content={item.data.submission?.content ?? '-'}
+                  content={
+                    item.data.submission?.resolvedContent?.content ??
+                    item.data.submission?.content ??
+                    '-'
+                  }
                   authorName={item.data.studentName}
                   regDate={item.data.submission?.modifiedSubmissionAt ?? '-'}
                   submitStatus={item.data.status}
@@ -105,7 +113,11 @@ export const StudentHomeworkDetail = ({ studyRoomId, homeworkId }: Props) => {
 
                 {item.data.feedback && (
                   <FeedbackAnswer
-                    content={item.data.feedback.content ?? ''}
+                    content={
+                      item.data.feedback.resolvedContent?.content ??
+                      item.data.feedback.content ??
+                      ''
+                    }
                     regDate={item.data.feedback.modifiedFeedbackAt ?? ''}
                     studyRoomId={studyRoomId}
                     homeworkId={homeworkId}

--- a/src/features/homework/components/detail/student-submission-content.tsx
+++ b/src/features/homework/components/detail/student-submission-content.tsx
@@ -1,8 +1,12 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Image from 'next/image';
 
-import { TextEditor, TextViewer } from '@/shared/components/editor';
+import {
+  TextEditor,
+  TextViewer,
+  prepareContentForSave,
+} from '@/shared/components/editor';
 import { Button } from '@/shared/components/ui';
 import { DropdownMenu } from '@/shared/components/ui/dropdown-menu';
 import { getRelativeTimeString } from '@/shared/lib/utils';
@@ -40,6 +44,11 @@ export const StudentSubmissionContent = ({
   const [editContent, setEditContent] = useState<JSONContent | null>(null);
   const [localContent, setLocalContent] = useState(content);
 
+  // content prop이 변경되면 localContent 동기화 (쿼리 refetch 후)
+  useEffect(() => {
+    setLocalContent(content);
+  }, [content]);
+
   const parsedContent = parseEditorContent(localContent);
 
   const { mutate: deleteHomework, isPending: isDeleting } =
@@ -54,17 +63,18 @@ export const StudentSubmissionContent = ({
 
   const handleSave = () => {
     if (!editContent) return;
+    const { contentString } = prepareContentForSave(editContent);
+
     updateHomework(
       {
         studyRoomId,
         homeworkStudentId,
         homeworkId,
-        content: JSON.stringify(editContent),
+        content: contentString,
       },
 
       {
         onSuccess: () => {
-          setLocalContent(JSON.stringify(editContent));
           setIsEditing(false);
           setEditContent(null);
         },

--- a/src/features/homework/components/detail/teacher-homework-detail.tsx
+++ b/src/features/homework/components/detail/teacher-homework-detail.tsx
@@ -33,7 +33,11 @@ export const TeacherHomeworkDetail = ({ studyRoomId, homeworkId }: Props) => {
       <ColumnLayout.Right className="desktop:max-w-[600px] flex w-full flex-col gap-3 rounded-[12px]">
         {/* 선생님이 낸 과제 */}
         <TeacherHomeworkContent
-          content={data.homework.content ?? ''}
+          content={
+            data.homework.resolvedContent?.content ??
+            data.homework.content ??
+            ''
+          }
           authorName={data.homework.teacherName ?? '-'}
           regDate={data.homework.modifiedAt ?? '-'}
         />
@@ -50,7 +54,11 @@ export const TeacherHomeworkDetail = ({ studyRoomId, homeworkId }: Props) => {
               {/* 학생 제출 */}
               <TeacherHomeworkSubmissionContent
                 homeworkStudentId={student.id}
-                content={student.submission.content ?? '-'}
+                content={
+                  student.submission.resolvedContent?.content ??
+                  student.submission.content ??
+                  '-'
+                }
                 authorName={student.studentName ?? '-'}
                 regDate={student.submission.modifiedSubmissionAt ?? '-'}
                 submitStatus={student.status}
@@ -62,7 +70,11 @@ export const TeacherHomeworkDetail = ({ studyRoomId, homeworkId }: Props) => {
               {/* 해당 학생의 피드백 */}
               {student.feedback && (
                 <FeedbackAnswer
-                  content={student.feedback.content ?? ''}
+                  content={
+                    student.feedback.resolvedContent?.content ??
+                    student.feedback.content ??
+                    ''
+                  }
                   regDate={student.feedback.modifiedFeedbackAt ?? ''}
                   studyRoomId={studyRoomId}
                   homeworkId={homeworkId}

--- a/src/features/homework/components/write/components/homework-feedback-answer.tsx
+++ b/src/features/homework/components/write/components/homework-feedback-answer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Image from 'next/image';
 
@@ -9,7 +9,11 @@ import {
   useUpdateTeacherHomeworkFeedback,
 } from '@/features/homework/hooks/teacher/useTeacherHomeworkFeedbackMutations';
 import { parseEditorContent } from '@/features/homework/lib/parse-editor-content';
-import { TextEditor, TextViewer } from '@/shared/components/editor';
+import {
+  TextEditor,
+  TextViewer,
+  prepareContentForSave,
+} from '@/shared/components/editor';
 import { Button } from '@/shared/components/ui/button';
 import { DropdownMenu } from '@/shared/components/ui/dropdown-menu';
 import { useRole } from '@/shared/hooks/use-role';
@@ -36,6 +40,11 @@ export const FeedbackAnswer = ({
   const [editContent, setEditContent] = useState<JSONContent | null>(null);
   const [localContent, setLocalContent] = useState(content);
 
+  // content prop이 변경되면 localContent 동기화 (쿼리 refetch 후)
+  useEffect(() => {
+    setLocalContent(content);
+  }, [content]);
+
   const { role } = useRole();
 
   const { mutate: updateMessage, isPending: isUpdating } =
@@ -54,16 +63,17 @@ export const FeedbackAnswer = ({
 
   const handleSave = () => {
     if (!editContent) return;
+    const { contentString } = prepareContentForSave(editContent);
+
     updateMessage(
       {
         studyRoomId,
         homeworkId,
         homeworkStudentId,
-        content: JSON.stringify(editContent),
+        content: contentString,
       },
       {
         onSuccess: () => {
-          setLocalContent(JSON.stringify(editContent));
           setIsEditing(false);
           setEditContent(null);
         },

--- a/src/features/homework/components/write/components/homework-form-provider.tsx
+++ b/src/features/homework/components/write/components/homework-form-provider.tsx
@@ -58,9 +58,10 @@ export const HomeworkFormProvider = ({
 
     const { homework } = homeworkDetail;
 
+    const contentString = homework.resolvedContent?.content || homework.content;
     let content;
     try {
-      content = JSON.parse(homework.content);
+      content = JSON.parse(contentString);
     } catch {
       content = {
         type: 'doc',

--- a/src/features/homework/model/homeworkDetail.types.ts
+++ b/src/features/homework/model/homeworkDetail.types.ts
@@ -7,6 +7,7 @@ export interface HomeworkDetail {
   teacherName: string;
   title: string;
   content: string;
+  resolvedContent?: { content: string };
   deadline: string;
   modifiedAt: string;
   reminderOffsets: ReminderOffset[];

--- a/src/features/homework/model/homeworkFeedback.types.ts
+++ b/src/features/homework/model/homeworkFeedback.types.ts
@@ -1,4 +1,5 @@
 export interface HomeworkFeedback {
   content: string;
+  resolvedContent?: { content: string };
   modifiedFeedbackAt: string;
 }

--- a/src/features/homework/model/homeworkSubmission.types.ts
+++ b/src/features/homework/model/homeworkSubmission.types.ts
@@ -1,4 +1,5 @@
 export interface HomeworkSubmission {
   content: string;
+  resolvedContent?: { content: string };
   modifiedSubmissionAt: string;
 }

--- a/src/features/qna/components/detail/qna-detail.tsx
+++ b/src/features/qna/components/detail/qna-detail.tsx
@@ -72,6 +72,7 @@ export function QuestionDetail({ studyRoomId, contextId }: Props) {
             authorType: string;
             id: Key | null | undefined;
             content: string;
+            resolvedContent?: { content: string };
             regDate: string;
             authorName: string;
           }) => {
@@ -80,7 +81,7 @@ export function QuestionDetail({ studyRoomId, contextId }: Props) {
                 <QuestionAnswer
                   key={msg.id}
                   id={Number(msg.id)}
-                  content={msg.content}
+                  content={msg.resolvedContent?.content || msg.content}
                   regDate={msg.regDate}
                   studyRoomId={studyRoomId}
                   contextId={contextId}
@@ -91,7 +92,7 @@ export function QuestionDetail({ studyRoomId, contextId }: Props) {
                 <QuestionContent
                   key={msg.id}
                   id={Number(msg.id)}
-                  content={msg.content}
+                  content={msg.resolvedContent?.content || msg.content}
                   authorName={msg.authorName}
                   regDate={msg.regDate}
                   studyRoomId={studyRoomId}

--- a/src/features/qna/components/sidebar/question-answer.tsx
+++ b/src/features/qna/components/sidebar/question-answer.tsx
@@ -4,7 +4,11 @@ import { useState } from 'react';
 
 import Image from 'next/image';
 
-import { TextEditor, TextViewer } from '@/shared/components/editor';
+import {
+  TextEditor,
+  TextViewer,
+  prepareContentForSave,
+} from '@/shared/components/editor';
 import { Button } from '@/shared/components/ui/button';
 import { DropdownMenu } from '@/shared/components/ui/dropdown-menu';
 import { useRole } from '@/shared/hooks/use-role';
@@ -83,12 +87,14 @@ const QuestionAnswer = ({
 
   const handleSave = () => {
     if (!editContent) return;
+    const { contentString } = prepareContentForSave(editContent);
+
     updateMessage(
       {
         studyRoomId,
         contextId,
         messageId: id,
-        content: JSON.stringify(editContent),
+        content: contentString,
       },
       {
         onSuccess: () => {

--- a/src/features/qna/components/sidebar/question-content.tsx
+++ b/src/features/qna/components/sidebar/question-content.tsx
@@ -4,7 +4,11 @@ import { useState } from 'react';
 
 import Image from 'next/image';
 
-import { TextEditor, TextViewer } from '@/shared/components/editor';
+import {
+  TextEditor,
+  TextViewer,
+  prepareContentForSave,
+} from '@/shared/components/editor';
 import { Button } from '@/shared/components/ui/button';
 import { DropdownMenu } from '@/shared/components/ui/dropdown-menu';
 import { useRole } from '@/shared/hooks/use-role';
@@ -84,12 +88,14 @@ const QuestionContent = ({
 
   const handleSave = () => {
     if (!editContent) return;
+    const { contentString } = prepareContentForSave(editContent);
+
     updateMessage(
       {
         studyRoomId,
         contextId,
         messageId: id,
-        content: JSON.stringify(editContent),
+        content: contentString,
       },
       {
         onSuccess: () => {


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 린트 에러가 없습니다.
- [ ] 코드가 올바르게 포맷팅되었습니다.
- [ ] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
<!-- 
- 변경된 내용에 대해 간략하게 설명해주세요.
- 예: 사용자 로그인 기능 추가
- 예: API 응답 구조 변경 
-->
  
과제, 질문 글 조회/작성/수정 시 이미지가 준비중으로 계속 표시되는 현상을 확인하였고, 에디터에 넘겨주는 content 값이 잘못되었다는 것을 파악했습니다.

api response로 전달받은 resolvedContent 를 에디터에 넘겨줌으로써 해결 할 수 있기에 수정하였습니다.
(경주님이랑 api 관련 에디터 표시는 resolvedContent를 사용해 달라고 전달 받았는데, 과제쪽 담당하시는 지환님께 전달을 하지 못한 것 이 원인인 것 같네요. 앞으로는 팀원끼리 관련 내용 공유하도록 하겠습니다, 이게 문제가 될 거라고 전혀 예상하지 못했네요.) 

## 🧐 관련 이슈
<!--
- 관련된 이슈 번호를 적어주세요. (ex. `Closes #123`, `Fixes #456`) 
-->

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->
<img width="3418" height="1882" alt="image" src="https://github.com/user-attachments/assets/0e817ac2-5807-4ccb-8b83-9728ec8c423c" />

이미지 업로드 로딩 블록으로만 표시되고 있는 것을 확인 할 수 있음.

## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
