### PR TITLE
fix : 수업노트/스터디룸 동기화 이슈 해결

### DIFF
--- a/src/app/(private)/study-rooms/[id]/note/page.tsx
+++ b/src/app/(private)/study-rooms/[id]/note/page.tsx
@@ -182,6 +182,7 @@ export default function StudyNotePage() {
         pageable={pageable}
         keyword={search}
         onRefresh={currentQuery.refetch}
+        canManage={role === 'ROLE_TEACHER'}
       />
     </StudyRoomDetailLayout>
   );

--- a/src/app/(private)/study-rooms/[id]/note/page.tsx
+++ b/src/app/(private)/study-rooms/[id]/note/page.tsx
@@ -25,6 +25,7 @@ import {
   StudyNoteSortKey,
 } from '@/features/study-notes/model';
 import { StudyRoomDetailLayout } from '@/features/study-rooms/components/common/layout';
+import { MiniSpinner } from '@/shared/components/loading';
 import { useRole } from '@/shared/hooks/use-role';
 
 export default function StudyNotePage() {
@@ -70,14 +71,6 @@ export default function StudyNotePage() {
     enabled: role === 'ROLE_STUDENT',
   });
 
-  const studyNotes =
-    role === 'ROLE_TEACHER' ? teacherListQuery.data : studentListQuery.data;
-
-  const isPending =
-    role === 'ROLE_TEACHER'
-      ? teacherListQuery.isPending
-      : studentListQuery.isPending;
-
   // ------------------------------------------------------------------
   // 그룹별 목록 조회
   // TODO: 추후 엔티티분리
@@ -108,11 +101,6 @@ export default function StudyNotePage() {
       : role === 'ROLE_TEACHER'
         ? teacherByGroupQuery
         : studentByGroupQuery;
-
-  const studyNotesByGroupId =
-    role === 'ROLE_TEACHER'
-      ? teacherByGroupQuery.data
-      : studentByGroupQuery.data;
 
   const setPage = useCallback(
     (page: number, { replace = false }: { replace?: boolean } = {}) => {
@@ -150,12 +138,13 @@ export default function StudyNotePage() {
 
   const page = {
     page: currentPage,
-    totalPages:
-      selectedGroupId === 'all'
-        ? studyNotes?.totalPages || 1
-        : studyNotesByGroupId?.totalPages || 1,
+    totalPages: currentQuery.data?.totalPages ?? 1,
     onPageChange: handlePageChange,
   };
+
+  if (!role) {
+    return <MiniSpinner />;
+  }
 
   return (
     <StudyRoomDetailLayout
@@ -172,12 +161,9 @@ export default function StudyNotePage() {
       page={page}
     >
       <StudyNotesList
-        data={
-          selectedGroupId === 'all'
-            ? studyNotes?.content || []
-            : studyNotesByGroupId?.content || []
-        }
-        isPending={isPending}
+        data={currentQuery.data?.content ?? []}
+        isPending={currentQuery.isPending}
+        isError={currentQuery.isError}
         studyRoomId={studyRoomId}
         pageable={pageable}
         keyword={search}

--- a/src/features/dashboard/studynote/detail/components/contents-section.tsx
+++ b/src/features/dashboard/studynote/detail/components/contents-section.tsx
@@ -9,6 +9,7 @@ import EllipsisIcon from '@/assets/icons/ellipsis-vertical.svg';
 import { useStudyNoteDetailQuery } from '@/features/dashboard/studynote/detail/service/query';
 import { ColumnLayout } from '@/layout/column-layout';
 import { TextViewer } from '@/shared/components/editor';
+import { useRole } from '@/shared/hooks';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 
@@ -16,6 +17,9 @@ const StudyNoteDetailContentsSection = ({ id }: { id: string }) => {
   const { data } = useStudyNoteDetailQuery(Number(id));
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const router = useRouter();
+
+  const { role } = useRole();
+  const canManage = role === 'ROLE_TEACHER';
 
   if (!data) return null;
 
@@ -52,45 +56,47 @@ const StudyNoteDetailContentsSection = ({ id }: { id: string }) => {
         </div>
 
         {/* 메뉴 버튼 */}
-        <div className="relative">
-          <button
-            onClick={() => setIsMenuOpen(!isMenuOpen)}
-            className="text-text-sub2 hover:text-text-main rounded p-1 transition-colors"
-            aria-label="메뉴"
-          >
-            <EllipsisIcon className="h-5 w-5" />
-          </button>
+        {canManage && (
+          <div className="relative">
+            <button
+              onClick={() => setIsMenuOpen(!isMenuOpen)}
+              className="text-text-sub2 hover:text-text-main cursor-pointer rounded p-1 transition-colors"
+              aria-label="메뉴"
+            >
+              <EllipsisIcon className="h-5 w-5" />
+            </button>
 
-          {/* 드롭다운 메뉴 */}
-          {isMenuOpen && (
-            <>
-              <div
-                className="fixed inset-0 z-10"
-                onClick={() => setIsMenuOpen(false)}
-              />
-              <div className="border-line-line1 absolute top-8 right-0 z-20 w-32 overflow-hidden rounded-lg border bg-white shadow-lg">
-                <button
-                  onClick={() => {
-                    handleEdit();
-                    setIsMenuOpen(false);
-                  }}
-                  className="text-text-main hover:bg-background-gray font-body2-normal w-full px-4 py-3 text-center transition-colors"
-                >
-                  편집하기
-                </button>
-                <button
-                  onClick={() => {
-                    handleDelete();
-                    setIsMenuOpen(false);
-                  }}
-                  className="text-key-color-primary hover:bg-background-gray font-body2-normal w-full px-4 py-3 text-center transition-colors"
-                >
-                  삭제하기
-                </button>
-              </div>
-            </>
-          )}
-        </div>
+            {/* 드롭다운 메뉴 */}
+            {isMenuOpen && (
+              <>
+                <div
+                  className="fixed inset-0 z-10"
+                  onClick={() => setIsMenuOpen(false)}
+                />
+                <div className="border-line-line1 absolute top-8 right-0 z-20 w-32 overflow-hidden rounded-lg border bg-white shadow-lg">
+                  <button
+                    onClick={() => {
+                      handleEdit();
+                      setIsMenuOpen(false);
+                    }}
+                    className="text-text-main hover:bg-background-gray font-body2-normal w-full px-4 py-3 text-center transition-colors"
+                  >
+                    편집하기
+                  </button>
+                  <button
+                    onClick={() => {
+                      handleDelete();
+                      setIsMenuOpen(false);
+                    }}
+                    className="text-key-color-primary hover:bg-background-gray font-body2-normal w-full px-4 py-3 text-center transition-colors"
+                  >
+                    삭제하기
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
       </div>
 
       <TextViewer value={content} />

--- a/src/features/study-notes/components/dropdown.tsx
+++ b/src/features/study-notes/components/dropdown.tsx
@@ -36,7 +36,6 @@ export const StudyNotesDropdown = ({
   };
 
   const handleDelete = () => {
-    // TODO: 수업노트 삭제 API 호출 후 상태 업데이트 로직 넣기
     dispatch({
       type: 'OPEN',
       scope: 'note',
@@ -107,7 +106,7 @@ export const StudyNotesDropdown = ({
           </DropdownMenu.Item>
           <DropdownMenu.Item asChild>
             <Link
-              href={`/dashboard/study-note/${item.id}/write`}
+              href={`/study-rooms/${studyRoomId}/note/${item.id}/edit`}
               className="justify-center border-none focus:ring-0 focus:outline-none"
             >
               편집하기

--- a/src/features/study-notes/components/list.tsx
+++ b/src/features/study-notes/components/list.tsx
@@ -17,6 +17,7 @@ import { StudyNotesDropdown } from './dropdown';
 export const StudyNotesList = ({
   data,
   isPending,
+  isError,
   studyRoomId,
   pageable,
   keyword,
@@ -25,6 +26,7 @@ export const StudyNotesList = ({
 }: {
   data: StudyNote[];
   isPending: boolean;
+  isError: boolean;
   studyRoomId: number;
   pageable: StudyNoteGroupPageable;
   keyword: string;
@@ -106,6 +108,14 @@ export const StudyNotesList = ({
     return (
       <p className="flex flex-col items-center">
         아직 등록된 수업노트가 없어요.
+      </p>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="flex flex-col items-center">
+        수업노트를 불러오지 못했어요.
       </p>
     );
   }

--- a/src/features/study-notes/components/list.tsx
+++ b/src/features/study-notes/components/list.tsx
@@ -20,6 +20,7 @@ export const StudyNotesList = ({
   studyRoomId,
   pageable,
   keyword,
+  canManage,
   onRefresh,
 }: {
   data: StudyNote[];
@@ -27,6 +28,7 @@ export const StudyNotesList = ({
   studyRoomId: number;
   pageable: StudyNoteGroupPageable;
   keyword: string;
+  canManage: boolean;
   onRefresh: () => void;
 }) => {
   const [open, setOpen] = useState(0);
@@ -99,6 +101,7 @@ export const StudyNotesList = ({
       </div>
     );
   }
+
   if (data.length === 0) {
     return (
       <p className="flex flex-col items-center">
@@ -126,15 +129,17 @@ export const StudyNotesList = ({
       }
       rightTitle={formatMMDDWeekday(item.taughtAt)}
       dropdown={
-        <StudyNotesDropdown
-          open={open}
-          handleOpen={handleOpen}
-          item={item}
-          studyRoomId={studyRoomId}
-          pageable={pageable}
-          keyword={keyword}
-          onRefresh={onRefresh}
-        />
+        canManage ? (
+          <StudyNotesDropdown
+            open={open}
+            handleOpen={handleOpen}
+            item={item}
+            studyRoomId={studyRoomId}
+            pageable={pageable}
+            keyword={keyword}
+            onRefresh={onRefresh}
+          />
+        ) : null
       }
       href={`/study-rooms/${studyRoomId}/note/${item.id}`}
       id={item.id}

--- a/src/features/study-rooms/api/room.query.keys.ts
+++ b/src/features/study-rooms/api/room.query.keys.ts
@@ -6,13 +6,6 @@ export const StudyRoomsQueryKey = {
   detail: (id: number) => ['studyRooms', 'detail', id] as const, // 상세지만 계층구조를 위해 studyRooms 으로 유지 (성진)
 };
 
-// 스터디노트 그룹 (목록)
-export const StudyRoomsGroupQueryKey = {
-  all: ['studyNoteGroups'] as const,
-  list: (studyRoomId: number) =>
-    ['studyNoteGroups', 'list', studyRoomId] as const,
-};
-
 // 학생 초대
 export const InvitationQueryKey = {
   all: ['invitations'] as const,

--- a/src/features/study-rooms/api/room.query.options.infinite.ts
+++ b/src/features/study-rooms/api/room.query.options.infinite.ts
@@ -1,5 +1,5 @@
 import { Role } from '@/entities/member';
-import { StudyRoomsGroupQueryKey } from '@/features/study-rooms';
+import { StudyRoomsGroupQueryKey } from '@/entities/study-note-group/infrastructure';
 import type { StudyNoteGroup } from '@/features/study-rooms/model/types';
 import type { Pageable, PaginationMeta } from '@/types/http';
 import { infiniteQueryOptions } from '@tanstack/react-query';

--- a/src/features/study-rooms/components/sidebar/groups/dialogs.tsx
+++ b/src/features/study-rooms/components/sidebar/groups/dialogs.tsx
@@ -4,9 +4,9 @@ import { ConfirmDialog } from '@/features/study-rooms/components/common/dialog/c
 import { InputDialog } from '@/features/study-rooms/components/common/dialog/input-dialog';
 import { DialogAction, DialogState } from '@/shared/components/dialog';
 
-import { useDeleteStudyNoteGroup } from '../services/query';
 import {
   useCreateStudyNoteGroup,
+  useDeleteStudyNoteGroup,
   useUpdateStudyNoteGroup,
 } from '../services/query';
 
@@ -29,6 +29,7 @@ export const StudyroomGroupDialogs = ({
 
   const handleCreateGroup = (title: string) => {
     createStudyNoteGroup({ studyRoomId, title });
+    dispatch({ type: 'CLOSE' });
   };
   const handleRename = (name: string) => {
     updateStudyNoteGroup({

--- a/src/features/study-rooms/components/sidebar/services/query.ts
+++ b/src/features/study-rooms/components/sidebar/services/query.ts
@@ -1,6 +1,8 @@
 import { StudyNoteQueryKey } from '@/entities/study-note';
 import { StudyRoomsGroupQueryKey } from '@/entities/study-note-group/infrastructure';
+import type { StudyNote } from '@/features/study-notes/model';
 import { StudyRoomDetail, StudyRoomsQueryKey } from '@/features/study-rooms';
+import type { PaginationData } from '@/types/http';
 import { useMutation } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -39,7 +41,47 @@ export const useUpdateStudyNoteGroup = () => {
       title: string;
       studyRoomId: number;
     }) => updateStudyNoteGroup(args),
-    onSuccess: (_, variables) => {
+
+    onMutate: async (variables) => {
+      const previous = queryClient.getQueriesData({
+        queryKey: StudyNoteQueryKey.all,
+      });
+
+      // Optimistic Update: 모든 노트 목록에서 그룹명 즉시 변경
+      queryClient.setQueriesData(
+        { queryKey: StudyNoteQueryKey.all },
+        (old: PaginationData<StudyNote> | undefined) => {
+          if (!old?.content) return old;
+          return {
+            ...old,
+            content: old.content.map((note) =>
+              note.groupId === variables.teachingNoteGroupId
+                ? { ...note, groupName: variables.title }
+                : note
+            ),
+          };
+        }
+      );
+
+      return { previous };
+    },
+
+    onError: (_, __, context) => {
+      context?.previous.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+    },
+
+    onSettled: (_, __, variables) => {
+      // 수정된 그룹의 노트 쿼리 제거
+      queryClient.removeQueries({
+        queryKey: StudyNoteQueryKey.byGroupPrefix(
+          variables.studyRoomId,
+          variables.teachingNoteGroupId
+        ),
+      });
+
+      // 그룹 목록 갱신
       queryClient.invalidateQueries({
         queryKey: [
           StudyRoomsGroupQueryKey.all,
@@ -49,14 +91,6 @@ export const useUpdateStudyNoteGroup = () => {
           },
           'ROLE_TEACHER',
         ],
-      });
-
-      queryClient.refetchQueries({
-        queryKey: StudyNoteQueryKey.all,
-      });
-
-      queryClient.removeQueries({
-        queryKey: StudyNoteQueryKey.all,
       });
     },
   });
@@ -67,7 +101,47 @@ export const useDeleteStudyNoteGroup = () => {
   return useMutation({
     mutationFn: (args: { teachingNoteGroupId: number; studyRoomId: number }) =>
       deleteStudyNoteGroup(args),
-    onSuccess: (_, variables) => {
+
+    onMutate: async (variables) => {
+      const previous = queryClient.getQueriesData({
+        queryKey: StudyNoteQueryKey.all,
+      });
+
+      // Optimistic Update: 모든 노트 목록에서 삭제된 그룹 정보 제거
+      queryClient.setQueriesData(
+        { queryKey: StudyNoteQueryKey.all },
+        (old: PaginationData<StudyNote> | undefined) => {
+          if (!old?.content) return old;
+          return {
+            ...old,
+            content: old.content.map((note) =>
+              note.groupId === variables.teachingNoteGroupId
+                ? { ...note, groupId: null, groupName: '' }
+                : note
+            ),
+          };
+        }
+      );
+
+      return { previous };
+    },
+
+    onError: (_, __, context) => {
+      context?.previous.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+    },
+
+    onSettled: (_, __, variables) => {
+      // 삭제된 그룹의 노트 쿼리 제거
+      queryClient.removeQueries({
+        queryKey: StudyNoteQueryKey.byGroupPrefix(
+          variables.studyRoomId,
+          variables.teachingNoteGroupId
+        ),
+      });
+
+      // 그룹 목록 갱신
       queryClient.invalidateQueries({
         queryKey: [
           StudyRoomsGroupQueryKey.all,
@@ -77,14 +151,6 @@ export const useDeleteStudyNoteGroup = () => {
           },
           'ROLE_TEACHER',
         ],
-      });
-
-      queryClient.refetchQueries({
-        queryKey: StudyNoteQueryKey.all,
-      });
-
-      queryClient.removeQueries({
-        queryKey: StudyNoteQueryKey.all,
       });
     },
   });

--- a/src/features/study-rooms/components/sidebar/services/query.ts
+++ b/src/features/study-rooms/components/sidebar/services/query.ts
@@ -1,9 +1,6 @@
 import { StudyNoteQueryKey } from '@/entities/study-note';
-import {
-  StudyRoomDetail,
-  StudyRoomsGroupQueryKey,
-  StudyRoomsQueryKey,
-} from '@/features/study-rooms';
+import { StudyRoomsGroupQueryKey } from '@/entities/study-note-group/infrastructure';
+import { StudyRoomDetail, StudyRoomsQueryKey } from '@/features/study-rooms';
 import { useMutation } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -19,9 +16,16 @@ export const useCreateStudyNoteGroup = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: createStudyNoteGroup,
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
-        queryKey: [StudyRoomsGroupQueryKey.all],
+        queryKey: [
+          StudyRoomsGroupQueryKey.all,
+          {
+            pageable: { page: 0, size: 20, sort: ['desc'] },
+            studyRoomId: variables.studyRoomId,
+          },
+          'ROLE_TEACHER',
+        ],
       });
     },
   });
@@ -35,13 +39,24 @@ export const useUpdateStudyNoteGroup = () => {
       title: string;
       studyRoomId: number;
     }) => updateStudyNoteGroup(args),
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
-        queryKey: [StudyRoomsGroupQueryKey.all],
+        queryKey: [
+          StudyRoomsGroupQueryKey.all,
+          {
+            pageable: { page: 0, size: 20, sort: ['desc'] },
+            studyRoomId: variables.studyRoomId,
+          },
+          'ROLE_TEACHER',
+        ],
       });
 
-      queryClient.invalidateQueries({
-        queryKey: [StudyNoteQueryKey.byGroupId],
+      queryClient.refetchQueries({
+        queryKey: StudyNoteQueryKey.all,
+      });
+
+      queryClient.removeQueries({
+        queryKey: StudyNoteQueryKey.all,
       });
     },
   });
@@ -52,13 +67,24 @@ export const useDeleteStudyNoteGroup = () => {
   return useMutation({
     mutationFn: (args: { teachingNoteGroupId: number; studyRoomId: number }) =>
       deleteStudyNoteGroup(args),
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
-        queryKey: [StudyRoomsGroupQueryKey.all],
+        queryKey: [
+          StudyRoomsGroupQueryKey.all,
+          {
+            pageable: { page: 0, size: 20, sort: ['desc'] },
+            studyRoomId: variables.studyRoomId,
+          },
+          'ROLE_TEACHER',
+        ],
       });
 
-      queryClient.invalidateQueries({
-        queryKey: [StudyNoteQueryKey.byGroupId],
+      queryClient.refetchQueries({
+        queryKey: StudyNoteQueryKey.all,
+      });
+
+      queryClient.removeQueries({
+        queryKey: StudyNoteQueryKey.all,
       });
     },
   });


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
**1. 수업노트 그룹 수정/삭제/이동 시 즉시 반영**
- 그룹 추가/수정/삭제 시 좌측 노트 그룹 리스트 즉시 반영
- 그룹 이름 수정/삭제 시 우측 노트 그룹 태그 즉시 반영: 캐시 제거로 동기화 문제 해결
- StudyRoomsGroupQueryKey 중복 제거
  - `entities/study-note-group/infrastructure/group.keys.ts`가 있는데 `room.query.keys.ts`의 StudyRoomsGroupQueryKey를 사용하고 있었습니다. group의 key가 더 명확하다고 판단하여 변경하고 사용되지 않는 코드는 제거했습니다.

**2. 스터디룸 이름 수정 시 상세 즉시 반영**
- 동작은 잘 되지만 시간이 걸려 즉시 반영이 어려운 것 같습니다. Optimistic Update 적용하여 해결했습니다.

**3. 학생 권한 수업노트 편집 제한**
- 학생은 노트 목록과 상세에서 Dropdown을 보이지 않도록 처리했습니다.
  - 수업노트목록: 제목수정, 그룹이동하기, 편집하기, 복제하기, 삭제하기 제한
  - 수업노트상세: 편집하기, 삭제하기 제한

**4. 로딩 상태 UI 명확화**
- 기존에 로딩 중 `데이터 없음`이 먼저 노출되던 문제 개선
- 이 과정에서 중복된 조건 분기가 있어 정리했습니다.
 
**5. 수업 노트 목록에서 편집하기 클릭 시 잘못된 이동 경로 수정**


## 🧐 관련 이슈
<!--
- 관련된 이슈 번호를 적어주세요. (ex. `Closes #123`, `Fixes #456`) 
-->
[디버깅 리스트](https://github.com/idealstudy/mvp-front/discussions/163)
- 1, 2, 3, 6, 13, 18, 24, 29 완료했습니다.
  - 4에서 편집은 단순 경로 문제로 해결했으며, 복제는 구현이 안 되어있습니다. API는 존재하니 연결하면 될 것 같습니다.
- 이 외에는 개별 이슈로 판단되어서 정리해서 노션 QA에 올려놓겠습니다.

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->

## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
