### PR TITLE
chore: 프로필 카드 하단 워딩 변경

### DIFF
--- a/src/features/list/components/teacher-card.tsx
+++ b/src/features/list/components/teacher-card.tsx
@@ -47,7 +47,7 @@ export const TeacherCard = ({ teacher }: TeacherCardProps) => {
         showDivider
         footer={
           <div className="group-hover:text-orange-7 text-gray-10 mt-1 flex items-center justify-end text-[14px] transition-colors md:text-[14px]">
-            스터디룸 바로가기
+            프로필 바로가기
             <IoIosArrowForward className="ml-1 h-[16px] w-[16px]" />
           </div>
         }


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
<!-- 
- 변경된 내용에 대해 간략하게 설명해주세요.
- 예: 사용자 로그인 기능 추가
- 예: API 응답 구조 변경 
-->
  - 프로필 카드 하단 워딩 
  스터디룸 바로가기 -> 프로필 바로가기
    로 변경
## 🧐 관련 이슈
<!--
- 관련된 이슈 번호를 적어주세요. (ex. `Closes #123`, `Fixes #456`) 
-->

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->
<table align="center">
  <tr>
    <td><img width="400" src="https://github.com/user-attachments/assets/0c584f0d-a7cb-40b3-8a27-fe36e4f5b6fa" /></td>
    <td style="padding: 0 20px; font-size:24px;">→</td>
    <td><img width="400" src="https://github.com/user-attachments/assets/ed7a2ace-8852-45ad-a0f9-3d2b98f40418" /></td>
  </tr>
</table>


## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
<a href="https://w1732339344-obo397870.slack.com/archives/C08262K9534/p1771404465950199">현수님 슬랙 내용</a>