### PR TITLE
BTS-548: 브라우저 내 쿠키 차단으로 인한 origin 삽입 취소, state 복구

### DIFF
--- a/src/app/(public)/invite/page.tsx
+++ b/src/app/(public)/invite/page.tsx
@@ -8,9 +8,9 @@ import { useAuth } from '@/features/auth/hooks/use-auth';
 import { InviteExitModal } from '@/features/invite/components/invite-exit-modal';
 import { InviteLetter } from '@/features/invite/components/invite-letter';
 import { InviteLoginModal } from '@/features/invite/components/invite-login-modal';
-import { INVITE_ERROR_CODE } from '@/features/invite/constants';
 import { useInvitation } from '@/features/invite/hooks';
 import { PRIVATE, PUBLIC } from '@/shared/constants';
+import { isAxiosError } from 'axios';
 
 export default function InvitePage() {
   const router = useRouter();
@@ -38,8 +38,8 @@ export default function InvitePage() {
 
   useEffect(() => {
     if (!error) return;
-    const message = error.response?.data?.message ?? '';
-    if (message === INVITE_ERROR_CODE.INVITATION_EXPIRED) {
+    const code = isAxiosError(error) ? error.response?.data?.code : undefined;
+    if (code === 'INVITATION_EXPIRED') {
       router.push(PUBLIC.CORE.INVITE.ERROR('EXPIRED_LINK'));
     } else {
       router.push(PUBLIC.CORE.INVITE.ERROR('INVALID_LINK'));

--- a/src/features/auth/components/social-login-button.tsx
+++ b/src/features/auth/components/social-login-button.tsx
@@ -15,11 +15,11 @@ export default function SocialLoginButton() {
 
   useEffect(() => {
     const state = inviteToken
-      ? `origin:${window.location.origin}|inviteToken:${inviteToken}`
-      : `origin:${window.location.origin}`;
+      ? `&state=${encodeURIComponent(`inviteToken:${inviteToken}`)}`
+      : '';
 
     setKakaoAuthUrl(
-      `https://kauth.kakao.com/oauth/authorize?client_id=${env.kakaoClientId}&redirect_uri=${serverEnv.backendApiUrl}/auth/kakao/callback&response_type=code&state=${encodeURIComponent(state)}`
+      `https://kauth.kakao.com/oauth/authorize?client_id=${env.kakaoClientId}&redirect_uri=${serverEnv.backendApiUrl}/auth/kakao/callback&response_type=code${state}`
     );
   }, [inviteToken]);
 

--- a/src/features/invite/components/invite-letter.tsx
+++ b/src/features/invite/components/invite-letter.tsx
@@ -17,7 +17,7 @@ export const InviteLetter = ({
 }: {
   onOpenLoginModal: () => void;
   onOpenExitModal: () => void;
-  data: InvitationInfoDTO | null;
+  data: InvitationInfoDTO | undefined;
   isLoading: boolean;
   token: string;
 }) => {

--- a/src/features/invite/constants/error-codes.ts
+++ b/src/features/invite/constants/error-codes.ts
@@ -1,10 +1,6 @@
-export const INVITE_ERROR_CODE = {
-  MEMBER_NOT_EXIST: '해당 ID를 가진 사용자가 존재하지 않습니다.',
-  STUDY_ROOM_NOT_EXIST: '해당 ID의 스터디룸이 존재하지 않습니다.',
-  INVITATION_EXPIRED: '초대장이 만료되었습니다.',
-  DUPLICATED_INVITEE: '해당 수신자는 이미 초대를 받은 수신자 입니다.',
-  STUDY_ROOM_CAPACITY_EXCEEDED: '초대하려는 인원 수가 수용인원을 초과합니다.',
-} as const;
-
 export type InviteErrorCode =
-  (typeof INVITE_ERROR_CODE)[keyof typeof INVITE_ERROR_CODE];
+  | 'MEMBER_NOT_EXIST'
+  | 'STUDY_ROOM_NOT_EXIST'
+  | 'INVITATION_EXPIRED'
+  | 'DUPLICATED_INVITEE'
+  | 'STUDY_ROOM_CAPACITY_EXCEEDED';

--- a/src/features/invite/hooks/use-accept-invitation.ts
+++ b/src/features/invite/hooks/use-accept-invitation.ts
@@ -3,9 +3,8 @@ import { useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { studyRoomRepository } from '@/entities/study-room';
-import { INVITE_ERROR_CODE } from '@/features/invite/constants';
 import { PUBLIC } from '@/shared/constants';
-import { AxiosError } from 'axios';
+import { isAxiosError } from 'axios';
 
 export const useAcceptInvitation = () => {
   const router = useRouter();
@@ -15,24 +14,21 @@ export const useAcceptInvitation = () => {
         const data = await studyRoomRepository.student.acceptInvitation(token);
         router.push(PUBLIC.CORE.INVITE.SUCCESS(data.studyRoomResponse.id));
       } catch (error) {
-        const message =
-          (error instanceof AxiosError
-            ? error.response?.data?.message
-            : undefined) ?? '';
-        switch (message) {
-          case INVITE_ERROR_CODE.INVITATION_EXPIRED:
+        const code = isAxiosError(error)
+          ? error.response?.data?.code
+          : undefined;
+        switch (code) {
+          case 'INVITATION_EXPIRED':
             router.push(PUBLIC.CORE.INVITE.ERROR('EXPIRED_LINK'));
             break;
-          case INVITE_ERROR_CODE.DUPLICATED_INVITEE:
+          case 'DUPLICATED_INVITEE':
             router.push(PUBLIC.CORE.INVITE.ERROR('ALREADY_PARTICIPATED'));
             break;
-          case INVITE_ERROR_CODE.STUDY_ROOM_CAPACITY_EXCEEDED:
+          case 'STUDY_ROOM_CAPACITY_EXCEEDED':
             router.push(
               PUBLIC.CORE.INVITE.ERROR('STUDY_ROOM_CAPACITY_EXCEEDED')
             );
             break;
-          case INVITE_ERROR_CODE.STUDY_ROOM_NOT_EXIST:
-          case INVITE_ERROR_CODE.MEMBER_NOT_EXIST:
           default:
             router.push(PUBLIC.CORE.INVITE.ERROR('INVALID_LINK'));
             break;

--- a/src/features/invite/hooks/use-invitation.ts
+++ b/src/features/invite/hooks/use-invitation.ts
@@ -1,26 +1,10 @@
-import { useEffect, useState } from 'react';
-
-import { InvitationInfoDTO, studyRoomRepository } from '@/entities/study-room';
-import { AxiosError } from 'axios';
+import { studyRoomRepository } from '@/entities/study-room';
+import { useQuery } from '@tanstack/react-query';
 
 export const useInvitation = (token: string | null) => {
-  const [data, setData] = useState<InvitationInfoDTO | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<AxiosError<{ message?: string }> | null>(
-    null
-  );
-
-  useEffect(() => {
-    if (!token) {
-      setIsLoading(false);
-      return;
-    }
-    studyRoomRepository
-      .getInvitationInfo(token)
-      .then(setData)
-      .catch(setError)
-      .finally(() => setIsLoading(false));
-  }, [token]);
-
-  return { data, isLoading, error };
+  return useQuery({
+    queryKey: ['invitation', token],
+    queryFn: () => studyRoomRepository.getInvitationInfo(token!),
+    enabled: !!token,
+  });
 };

--- a/src/stories/invite-letter.stories.tsx
+++ b/src/stories/invite-letter.stories.tsx
@@ -73,7 +73,7 @@ export const ShortNames: Story = {
 
 export const Loading: Story = {
   args: {
-    data: null,
+    data: undefined,
     isLoading: true,
     token: 'sample-token',
     onOpenLoginModal: () => {},


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 린트 에러가 없습니다.
- [ ] 코드가 올바르게 포맷팅되었습니다.
- [ ] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
- origin을 삽입했을 때 Authorization 쿠키가 안들어감을 확인
- origin 코드 삭제하고, 소셜 가입/로그인은 개발 서버에서 테스트해야할 것 같습니다.
  
## 🧐 관련 이슈
BTS-548

## 📷 스크린샷 or 코드 (선택사항)

## 📚 참고 자료
