### PR TITLE
QA-48: 대시보드 노트 섹션 캐싱 오류 수정

### DIFF
--- a/src/features/dashboard/studynote/write/services/query.ts
+++ b/src/features/dashboard/studynote/write/services/query.ts
@@ -25,13 +25,8 @@ export const useWriteStudyNoteMutation = () => {
   return useMutation({
     mutationFn: (data: StudyNote) => writeStudyNote(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: [
-          ...StudyNoteQueryKey.all,
-          ...teacherKeys.dashboard.all(),
-          'noteList',
-        ],
-      });
+      queryClient.invalidateQueries({ queryKey: StudyNoteQueryKey.all });
+      queryClient.invalidateQueries({ queryKey: teacherKeys.dashboard.all() });
     },
   });
 };


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 린트 에러가 없습니다.
- [ ] 코드가 올바르게 포맷팅되었습니다.
- [ ] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
- 대시보드 노트 섹션에서 노트를 추가했을 때, 바로 반영이 안되는 문제 해결
    - query invalidate 로직 오류 수정

## 🧐 관련 이슈
QA-48

## 📷 스크린샷 or 코드 (선택사항)

## 📚 참고 자료
