### PR TITLE
QA-40 수업노트 수정 폼 버그 수정

### DIFF
--- a/src/features/dashboard/studynote/detail/type.ts
+++ b/src/features/dashboard/studynote/detail/type.ts
@@ -15,6 +15,13 @@ export interface StudyNoteDetail {
     content: string;
   };
   taughtAt: string;
-  visibility: 'PUBLIC' | 'PRIVATE';
+  visibility:
+    | 'PUBLIC'
+    | 'PRIVATE'
+    | 'TEACHER_ONLY'
+    | 'SPECIFIC_STUDENTS_ONLY'
+    | 'SPECIFIC_STUDENTS_AND_PARENTS'
+    | 'STUDY_ROOM_STUDENTS_ONLY'
+    | 'STUDY_ROOM_STUDENTS_AND_PARENTS';
   studentInfos: StudentInfo[];
 }

--- a/src/features/dashboard/studynote/write/components/form-provider.tsx
+++ b/src/features/dashboard/studynote/write/components/form-provider.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { useStudyNoteDetailQuery } from '@/features/dashboard/studynote/detail/service/query';
+import { StudyNoteDetail } from '@/features/dashboard/studynote/detail/type';
 import { mergeResolvedContentWithMediaIds } from '@/shared/components/editor';
 import { zodResolver } from '@hookform/resolvers/zod';
 
@@ -30,72 +30,89 @@ export const StudyNoteFormProvider = ({
     enabled: isEditMode && !!noteId,
   });
 
+  if (isEditMode && (isLoading || !noteDetail)) return <div>로딩 중...</div>;
+
+  return (
+    <StudyNoteFormProviderInner
+      defaultStudyRoomId={defaultStudyRoomId}
+      noteDetail={isEditMode ? noteDetail : undefined}
+      isEditMode={isEditMode}
+    >
+      {children}
+    </StudyNoteFormProviderInner>
+  );
+};
+
+// 폼 초기화 담당
+const StudyNoteFormProviderInner = ({
+  defaultStudyRoomId,
+  noteDetail,
+  isEditMode,
+  children,
+}: {
+  defaultStudyRoomId: number;
+  noteDetail?: StudyNoteDetail;
+  isEditMode: boolean;
+  children: React.ReactNode;
+}) => {
   const methods = useForm<StudyNoteForm>({
     resolver: zodResolver(studyNoteFormSchema),
-    defaultValues: {
-      title: '',
-      content: {},
-      studentIds: [],
-      studyRoomId: defaultStudyRoomId,
-      taughtAt: new Date().toISOString().split('T')[0],
-    },
+    defaultValues:
+      isEditMode && noteDetail
+        ? computeDefaultValues(noteDetail)
+        : {
+            title: '',
+            content: {},
+            studentIds: [],
+            studyRoomId: defaultStudyRoomId,
+            taughtAt: new Date().toISOString().split('T')[0],
+          },
     mode: 'onChange',
   });
 
-  // 편집 모드일 때 기존 데이터로 폼 초기화
-  useEffect(() => {
-    if (isEditMode && noteDetail && !isLoading) {
-      const rawContentString = noteDetail.content;
-      const resolvedContentString = noteDetail.resolvedContent?.content;
-      const emptyDoc = { type: 'doc', content: [{ type: 'paragraph' }] };
-      const parseContent = (value: string) => {
-        try {
-          return JSON.parse(value);
-        } catch {
-          return emptyDoc;
-        }
-      };
-
-      const rawContent = parseContent(rawContentString);
-      const resolvedContent = parseContent(
-        resolvedContentString ?? rawContentString
-      );
-
-      const content = resolvedContentString
-        ? mergeResolvedContentWithMediaIds(rawContent, resolvedContent)
-        : rawContent;
-
-      // visibility 변환: 'PUBLIC' | 'PRIVATE' -> 폼 스키마 타입
-      const visibility =
-        noteDetail.visibility === 'PRIVATE'
-          ? 'TEACHER_ONLY'
-          : noteDetail.visibility;
-
-      const formData = {
-        title: noteDetail.title,
-        content,
-        studentIds: noteDetail.studentInfos.map((info) => ({
-          id: info.studentId,
-        })),
-        studyRoomId: noteDetail.studyRoomId,
-        taughtAt: new Date(noteDetail.taughtAt).toISOString().split('T')[0],
-        visibility: visibility as
-          | 'TEACHER_ONLY'
-          | 'SPECIFIC_STUDENTS_ONLY'
-          | 'SPECIFIC_STUDENTS_AND_PARENTS'
-          | 'STUDY_ROOM_STUDENTS_ONLY'
-          | 'STUDY_ROOM_STUDENTS_AND_PARENTS'
-          | 'PUBLIC',
-        teachingNoteGroupId: noteDetail.groupId ?? undefined,
-      };
-
-      methods.reset(formData);
-    }
-  }, [isEditMode, noteDetail, isLoading, methods]);
-
-  if (isEditMode && isLoading) {
-    return <div>로딩 중...</div>;
-  }
-
   return <FormProvider {...methods}>{children}</FormProvider>;
 };
+
+function computeDefaultValues(noteDetail: StudyNoteDetail) {
+  const rawContentString = noteDetail.content;
+  const resolvedContentString = noteDetail.resolvedContent?.content;
+  const emptyDoc = { type: 'doc', content: [{ type: 'paragraph' }] };
+  const parseContent = (value: string) => {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return emptyDoc;
+    }
+  };
+
+  const rawContent = parseContent(rawContentString);
+  const resolvedContent = parseContent(
+    resolvedContentString ?? rawContentString
+  );
+
+  const content = resolvedContentString
+    ? mergeResolvedContentWithMediaIds(rawContent, resolvedContent)
+    : rawContent;
+
+  const serverVisibility = noteDetail.visibility;
+  const isGuardianVisible =
+    serverVisibility === 'SPECIFIC_STUDENTS_AND_PARENTS' ||
+    serverVisibility === 'STUDY_ROOM_STUDENTS_AND_PARENTS';
+  const visibility =
+    serverVisibility === 'SPECIFIC_STUDENTS_AND_PARENTS'
+      ? 'SPECIFIC_STUDENTS_ONLY'
+      : serverVisibility === 'STUDY_ROOM_STUDENTS_AND_PARENTS'
+        ? 'STUDY_ROOM_STUDENTS_ONLY'
+        : serverVisibility;
+
+  return {
+    title: noteDetail.title,
+    content,
+    studentIds: noteDetail.studentInfos.map((info) => ({ id: info.studentId })),
+    studyRoomId: noteDetail.studyRoomId,
+    taughtAt: new Date(noteDetail.taughtAt).toISOString().split('T')[0],
+    visibility: visibility as StudyNoteForm['visibility'],
+    isGuardianVisible,
+    teachingNoteGroupId: noteDetail.groupId ?? undefined,
+  };
+}

--- a/src/features/dashboard/studynote/write/components/submit-section.tsx
+++ b/src/features/dashboard/studynote/write/components/submit-section.tsx
@@ -22,7 +22,7 @@ const SubmitSection = ({
     !isValid || isPending || isSubmitting || (isEditMode && !isDirty);
 
   return (
-    <div className="flex justify-end">
+    <div className="flex flex-col items-end gap-2">
       <Button
         type="submit"
         disabled={isButtonDisabled}
@@ -30,6 +30,10 @@ const SubmitSection = ({
       >
         {isPending ? '저장 중...' : isEditMode ? '수정하기' : '저장하기'}
       </Button>
+
+      {isEditMode && !isDirty && (
+        <p className="text-text-sub2">변경사항이 없습니다.</p>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
- 수업노트 수정 폼 공개 범위 초기화 버그 수정
  - 기존 코드: useEffect + methods.reset()으로 폼을 초기화
  - 문제 원인: Radix UI Select는 value가 undefined로 첫 렌더링된 후 값이 변경되어도 표시 텍스트를 갱신하지 않는 문제로 인해 다른 필드(input, textarea 등)는 정상 동작하지만 Radix Select만 영향을 받음.
- 수업노트 수정 폼 변경사항 없을 때 안내 문구 추가

  
## 🧐 관련 이슈
QA-40

## 📷 스크린샷 or 코드 (선택사항)
<img width="525" height="212" alt="image" src="https://github.com/user-attachments/assets/986151f3-e3b0-4719-b762-2e80dcfc35e0" />

## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
