### PR TITLE
BTS-727 문의 답변 수정 시 이미지 깨지는 버그 수정

### DIFF
--- a/src/features/inquiry/components/inquiry-answer-write.tsx
+++ b/src/features/inquiry/components/inquiry-answer-write.tsx
@@ -16,6 +16,7 @@ import {
 import {
   TextEditor,
   initialTextEditorValue,
+  mergeResolvedContentWithMediaIds,
   parseEditorContent,
   prepareContentForSave,
 } from '@/shared/components/editor';
@@ -57,7 +58,10 @@ export default function InquiryAnswerWrite({
   // 수정 모드일 경우, 초기값 세팅
   const initialContent =
     isEditMode && inquiry.answer
-      ? parseEditorContent(inquiry.answer.resolvedContent.content)
+      ? mergeResolvedContentWithMediaIds(
+          parseEditorContent(inquiry.answer.content),
+          parseEditorContent(inquiry.answer.resolvedContent.content)
+        )
       : initialTextEditorValue;
 
   const {


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
<!-- 
- 변경된 내용에 대해 간략하게 설명해주세요.
- 예: 사용자 로그인 기능 추가
- 예: API 응답 구조 변경 
-->
문의 답변 수정 시 기존 이미지 만료 후 깨지는 버그 수정
- resolvedContent만 사용하던 방식에서 mergeResolvedContentWithMediaIds로 mediaId를 복원하도록 변경
- 저장 시 media:// 형식으로 정상 저장되어 URL 만료 문제 해결
  
## 🧐 관련 이슈
<!--
- 관련된 이슈 번호를 적어주세요. (ex. `Closes #123`, `Fixes #456`) 
-->
BTS-727

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->

## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
