### PR TITLE
BTS-696 칼럼 수정 시 이미지 만료 버그 수정

### DIFF
--- a/src/entities/column/infrastructure/column.dto.ts
+++ b/src/entities/column/infrastructure/column.dto.ts
@@ -32,6 +32,7 @@ const ColumnDetailDtoSchema = z.object({
   authorNickname: z.string().nullable(),
   tags: z.array(z.string()),
   thumbnailUrl: z.string().nullable(),
+  content: z.string(),
   resolvedContent: z.object({
     content: z.string(),
     expiresAt: z.string().nullable(),

--- a/src/features/community/column/components/column-write-area.tsx
+++ b/src/features/community/column/components/column-write-area.tsx
@@ -19,6 +19,7 @@ import {
 import {
   TextEditor,
   initialTextEditorValue,
+  mergeResolvedContentWithMediaIds,
   parseEditorContent,
   prepareContentForSave,
 } from '@/shared/components/editor';
@@ -53,12 +54,6 @@ const getFirstImageMediaId = (node: JSONContent): string | undefined => {
 const hasUploadingNode = (node: JSONContent): boolean => {
   if (node.attrs?.isUploading === true) return true;
   return (node.content ?? []).some(hasUploadingNode);
-};
-
-// 이미지(썸네일) 존재 여부 확인
-const hasImageNode = (node: JSONContent): boolean => {
-  if (node.type === 'image') return true;
-  return (node.content ?? []).some(hasImageNode);
 };
 
 export default function ColumnWriteArea({
@@ -120,7 +115,10 @@ export default function ColumnWriteArea({
     if (existingData && isEditMode) {
       reset({
         title: existingData.title,
-        content: parseEditorContent(existingData.resolvedContent.content),
+        content: mergeResolvedContentWithMediaIds(
+          parseEditorContent(existingData.content),
+          parseEditorContent(existingData.resolvedContent.content)
+        ),
         tags: existingData.tags,
       });
     }
@@ -172,7 +170,7 @@ export default function ColumnWriteArea({
     const thumbnailMediaId = getFirstImageMediaId(data.content);
 
     // 썸네일용 사진이 없을 경우, 알림
-    if (!thumbnailMediaId && !hasImageNode(data.content)) {
+    if (!thumbnailMediaId) {
       setShowImageDialog(true);
       return;
     }


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
<!-- 
- 변경된 내용에 대해 간략하게 설명해주세요.
- 예: 사용자 로그인 기능 추가
- 예: API 응답 구조 변경 
-->
- ColumnDetailDtoSchema에 content 필드 추가
- hasImageNode 제거 및 썸네일 조건 단순화
  
## 🧐 관련 이슈
<!--
- 관련된 이슈 번호를 적어주세요. (ex. `Closes #123`, `Fixes #456`) 
-->
BTS-696

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->

## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
