### PR TITLE
BTS-727 소셜 로그인 후 복귀 지원 및 안내 문구 개선

### DIFF
--- a/src/app/(private)/dashboard/page.tsx
+++ b/src/app/(private)/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import { redirect } from 'next/navigation';
 
 import { DashboardContainer } from '@/features/dashboard/components/dashboard-container';
 import { EmptyConnectionDialog } from '@/features/dashboard/connect/components/empty-connection-dialog';
@@ -39,7 +40,19 @@ export const metadata: Metadata = {
   },
 };
 
-export default function HomePage() {
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ from?: string }>;
+}) {
+  // OAuth 전용 리다이렉트
+  const { from } = await searchParams;
+
+  if (from) {
+    const decoded = decodeURIComponent(from);
+    if (decoded.startsWith('/')) redirect(decoded);
+  }
+
   return (
     <>
       <DashboardContainer />

--- a/src/features/auth/components/social-login-button.tsx
+++ b/src/features/auth/components/social-login-button.tsx
@@ -11,18 +11,22 @@ export default function SocialLoginButton() {
   const searchParams = useSearchParams();
   const error = searchParams.get('error');
   const inviteToken = searchParams.get('token');
+  const from = searchParams.get('from');
 
   const [kakaoAuthUrl, setKakaoAuthUrl] = useState('');
 
   useEffect(() => {
-    const state = inviteToken
-      ? `&state=${encodeURIComponent(`inviteToken:${inviteToken}`)}`
+    const stateParts: string[] = [];
+    if (inviteToken) stateParts.push(`inviteToken:${inviteToken}`);
+    if (from) stateParts.push(`from:${encodeURIComponent(from)}`);
+    const state = stateParts.length
+      ? `&state=${encodeURIComponent(stateParts.join('|'))}`
       : '';
 
     setKakaoAuthUrl(
       `https://kauth.kakao.com/oauth/authorize?client_id=${env.kakaoClientId}&redirect_uri=${serverEnv.backendApiUrl}/auth/kakao/callback&response_type=code${state}`
     );
-  }, [inviteToken]);
+  }, [inviteToken, from]);
 
   return (
     <div className="my-4 block items-center">

--- a/src/features/auth/components/social-select-role.tsx
+++ b/src/features/auth/components/social-select-role.tsx
@@ -21,6 +21,7 @@ export const SocialSelectRole = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const inviteToken = searchParams.get('token');
+  const from = searchParams.get('from');
   const session = useSession();
   const { mutate: updateProfile, isPending } = useUpdateProfile();
   const { acceptInvitation } = useAcceptInvitation();
@@ -47,7 +48,7 @@ export const SocialSelectRole = () => {
             router.push(PUBLIC.CORE.INVITE.ERROR('ROLE_NOT_MATCH'));
           }
         } else {
-          router.push('/dashboard');
+          router.push(from ? decodeURIComponent(from) : '/dashboard');
         }
       },
       onError: () => {

--- a/src/features/inquiry/components/inquiry-write-area.tsx
+++ b/src/features/inquiry/components/inquiry-write-area.tsx
@@ -321,7 +321,7 @@ export default function InquiryWriteArea({
         }}
         onCancel={() => setIsLoginModalOpen(false)}
         title="로그인이 필요해요"
-        description="로그인 후 문의를 남길 수 있어요."
+        description="작성 중인 내용은 로그인 후 이어서 작성할 수 있어요."
         confirmText="로그인하기"
         cancelText="취소"
       />


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
1. 소셜 로그인 후 기존 페이지로 돌아올 수 있도록 from 파라미터 추가했습니다.
- social-login-button: state에 from 포함하여 백엔드로 전달
- dashboard: OAuth 콜백 후 from 쿼리로 서버사이드 리다이렉트
- social-select-role: 프로필 완성 후 from 경로로 이동

2. 안내 문구 개선했습니다.
- 전: 로그인 후 문의를 남길 수 있어요.
- 후: 작성 중인 내용은 로그인 후 이어서 작성할 수 있어요.
  
## 🧐 관련 이슈
BTS-727

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->

## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
