### PR TITLE
QA-18 로그아웃 실패 응답에도 Set-Cookie 헤더 적용

### DIFF
--- a/src/app/api/v1/auth/logout/route.ts
+++ b/src/app/api/v1/auth/logout/route.ts
@@ -30,7 +30,12 @@ export async function POST(request: NextRequest) {
 
   if (!logoutResponse.ok && logoutResponse.status !== 204) {
     const message = extractErrorMessage(payload) ?? '로그아웃에 실패했습니다.';
-    return NextResponse.json({ message }, { status: logoutResponse.status });
+    const errorResponse = NextResponse.json(
+      { message },
+      { status: logoutResponse.status }
+    );
+    applySetCookies(logoutResponse, errorResponse);
+    return errorResponse;
   }
 
   return response;


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
<!-- 
- 변경된 내용에 대해 간략하게 설명해주세요.
- 예: 사용자 로그인 기능 추가
- 예: API 응답 구조 변경 
-->
[문제] 만료된 토큰으로 로그아웃 요청 시 백엔드가 401을 반환하는 경우, Authorization 쿠키가 브라우저에 남아있는 현상
[원인] `/api/v1/auth/logout` BFF 라우트에서 에러 응답 시 새 NextResponse를 생성해 반환하면서 applySetCookies가 적용된 기존 response 객체가 버려짐. 백엔드가 에러 응답에도 Set-Cookie를 내려주고 있었으나 브라우저에 전달되지 않음.
[수정] 에러 응답 객체에도 applySetCookies 적용하여 백엔드의 Set-Cookie 헤더가 브라우저에 전달되도록 수정

- 오프라인 회의 시 발생했던 문제도 동일한 문제로 추정됩니다: 
  - 로그인/로그아웃 반복 시 백엔드 세션 상태가 불안정해져서 에러 응답이 나오는 빈도가 높아지고, 그때마다 쿠키가 안 지워짐
- 적용 후에도 동일한 문제가 발생하면 다른 방법 찾아보겠습니다!
  - 다음으로 고려중인 해결 방법은 성공 로그아웃 경로에서도 쿠키 삭제를 서버 응답에만 맡기지 말고, 직접 삭제 폴백을 넣는 것입니다.

## 🧐 관련 이슈
<!--
- 관련된 이슈 번호를 적어주세요. (ex. `Closes #123`, `Fixes #456`) 
-->
QA-18

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->

## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
