### PR TITLE
chore: Claude Code Action 권한 업그레이드 및 Slack 알림 추가

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,7 +43,7 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 
-      # 자동 리뷰 완료 시 백엔드 Slack 채널에 알림. 기존 PR open 알림과는 별도 메시지로 구분.
+      # 자동 리뷰 완료 시 프론트엔드 Slack 채널에 알림. 기존 PR open 알림과는 별도 메시지로 구분.
       - name: Notify Slack on review complete
         if: always()
         uses: slackapi/slack-github-action@v2.1.0
@@ -51,7 +51,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: ${{ secrets.SLACK_BACKEND_CHANNEL_ID }}
+            channel: ${{ secrets.SLACK_FRONTEND_CHANNEL_ID }}
             text: "Claude 자동 리뷰 완료 (${{ steps.claude-review.outcome }})\n- PR: <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>\n- 작성자: ${{ github.event.pull_request.user.login }}"
             unfurl_links: false
             unfurl_media: false

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,8 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    # synchronize 제거: 매 푸시마다 자동 리뷰가 돌면 Max 쿼터 소비가 커서 PR open/reopen/ready 시점만 동작하도록 축소.
+    types: [opened, reopened, ready_for_review]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -21,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write  # 자동 리뷰가 PR에 인라인 코멘트와 요약 코멘트를 작성할 수 있도록 write
       issues: read
       id-token: write
 
@@ -41,4 +42,17 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+
+      # 자동 리뷰 완료 시 백엔드 Slack 채널에 알림. 기존 PR open 알림과는 별도 메시지로 구분.
+      - name: Notify Slack on review complete
+        if: always()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_BACKEND_CHANNEL_ID }}
+            text: "Claude 자동 리뷰 완료 (${{ steps.claude-review.outcome }})\n- PR: <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>\n- 작성자: ${{ github.event.pull_request.user.login }}"
+            unfurl_links: false
+            unfurl_media: false
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,11 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write       # Claude가 PR 브랜치에 커밋 푸시할 수 있도록 write
+      pull-requests: write  # Claude가 PR 코멘트/리뷰를 작성할 수 있도록 write
+      issues: write         # Claude가 이슈 코멘트를 작성할 수 있도록 write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read         # Claude가 PR의 CI 결과를 읽을 수 있도록 필요
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -47,4 +47,17 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
+
+      # Claude 응답 완료 시 백엔드 Slack 채널에 알림. 성공/실패 모두 통지하여 쿼터 소진 등 에러 상황도 추적 가능하게 함.
+      - name: Notify Slack on Claude response
+        if: always()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_BACKEND_CHANNEL_ID }}
+            text: "Claude가 응답했습니다 (${{ steps.claude.outcome }})\n- 위치: <${{ github.event.issue.pull_request.html_url || github.event.issue.html_url || github.event.pull_request.html_url }}|보러 가기>\n- 호출자: ${{ github.event.comment.user.login || github.event.review.user.login || github.event.issue.user.login }}"
+            unfurl_links: false
+            unfurl_media: false
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -48,7 +48,7 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
 
-      # Claude 응답 완료 시 백엔드 Slack 채널에 알림. 성공/실패 모두 통지하여 쿼터 소진 등 에러 상황도 추적 가능하게 함.
+      # Claude 응답 완료 시 프론트엔드 Slack 채널에 알림. 성공/실패 모두 통지하여 쿼터 소진 등 에러 상황도 추적 가능하게 함.
       - name: Notify Slack on Claude response
         if: always()
         uses: slackapi/slack-github-action@v2.1.0
@@ -56,7 +56,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: ${{ secrets.SLACK_BACKEND_CHANNEL_ID }}
+            channel: ${{ secrets.SLACK_FRONTEND_CHANNEL_ID }}
             text: "Claude가 응답했습니다 (${{ steps.claude.outcome }})\n- 위치: <${{ github.event.issue.pull_request.html_url || github.event.issue.html_url || github.event.pull_request.html_url }}|보러 가기>\n- 호출자: ${{ github.event.comment.user.login || github.event.review.user.login || github.event.issue.user.login }}"
             unfurl_links: false
             unfurl_media: false


### PR DESCRIPTION
## 작업 내용

`/install-github-app`으로 머지된 두 워크플로우(`claude.yml`, `claude-code-review.yml`)를 조정하고, 프로젝트 스코프 MCP 설정(`.mcp.json`)을 추가하여 팀이 GitHub와 로컬 양쪽에서 Claude를 활용할 수 있게 한다.

### 변경 요약

- `claude.yml` 권한 read → write (코드 수정/커밋, 코멘트 작성 가능)
- `claude-code-review.yml` synchronize 트리거 제거 (쿼터 절약)
- 두 워크플로우 끝에 백엔드 Slack 채널 알림 step 추가
- `.mcp.json` 추가: 프로젝트 스코프 Notion MCP (팀원 클론 시 자동 인식)

---

## 머지 후 가능해지는 것

### 1. PR open 시 자동 코드 리뷰 (멘션 불필요)

PR open/reopen/ready_for_review 시점에 Claude 봇이 자동으로 인라인 + 요약 코멘트를 생성한다. `CLAUDE.md`의 코딩 컨벤션을 컨텍스트로 사용. synchronize는 제외해 매 push마다 돌지 않는다. 결과는 백엔드 Slack 채널에 "Claude 자동 리뷰 완료" 알림.

### 2. PR `@claude` 멘션 — 분석/리뷰만 (커밋 X)

PR 코멘트, PR 리뷰 본문, PR 리뷰 인라인 코멘트 어디서든 호출 가능. 응답은 PR 코멘트로 작성됨.

### 3. PR `@claude` 멘션 — 코드 수정 + 자동 커밋 (신규)

`contents: write` 권한으로 Claude가 PR 브랜치에 직접 커밋 푸시 가능. 커밋 작성자는 claude bot.

### 4. 이슈 `@claude` 멘션 (신규)

이슈 본문/제목/코멘트에서 호출 가능. 응답은 이슈 코멘트로 작성. 이론상 새 브랜치 생성 + PR open까지 가능.

### 5. `.mcp.json` 자동 공유 (신규)

팀원이 `git pull` 후 로컬에서 `claude` 실행 시 Notion MCP 자동 인식. OAuth 인증은 각자 1회 필요(`/mcp` 명령).

---

## 역할별 사용 가이드

### 기획자 / 디자이너

PR/이슈에서 이해·분석·요구사항 정리 중심으로 활용. 백엔드 코드 직접 수정 지시는 비추.

| 시나리오 | 명령 예시 | 결과 |
| --- | --- | --- |
| PR 의도 이해 | `@claude 이 PR이 어떤 사용자 시나리오를 다루는지 비전공자도 이해하게 풀어줘` | PR 코멘트로 한국어 설명 — 변경 의도, 영향 화면·플로우, 사용자 관점 동작 변화 |
| 사용자 영향 파악 | `@claude 이 변경이 회원가입/결제 플로우에 영향을 주는지 알려줘` | PR 코멘트: 영향 있는 영역과 없는 영역을 분리 정리 |
| 응답 메시지 검토 | `@claude 사용자한테 노출되는 에러 메시지를 모두 한국어로 모아줘` | PR 코멘트: 변경된 메시지 목록을 파일·라인과 함께 정리 |
| 요구사항 분해 (이슈) | `@claude 이 요구사항을 백엔드 작업으로 분해해줘` | 이슈 코멘트: 작업 체크리스트와 각 항목 영향 영역 |
| 도메인 위치 매칭 | `@claude "그룹스터디 매니저 권한" 처리 코드가 어디에 있는지 알려줘` | PR/이슈 코멘트: 관련 파일 경로와 해당 부분 코드 인용 |

### 개발자

| 시나리오 | 명령 예시 | 결과 |
| --- | --- | --- |
| 일반 코드 리뷰 | `@claude 이 PR 리뷰해줘` | 인라인 코멘트(이슈 라인 표시)와 마지막에 요약 코멘트 |
| 좁은 범위 리뷰 | `@claude 트랜잭션 경계와 N+1만 봐줘` | 좁은 범위 한정 인라인과 요약 |
| 보안 점검 | `@claude SQL injection / 민감정보 로그 / HMAC 누락 봐줘` | 보안 관점 인라인과 위험도(High/Med/Low) 표시 요약 |
| 코드 수정 + 자동 커밋 | `@claude OrderService에 null 체크 추가해줘` | PR 브랜치에 새 커밋 푸시(작성자 claude bot)와 변경 요약 코멘트 |
| 리팩토링 | `@claude 이 DTO를 record로 바꾸고 호출부도 같이 고쳐줘` | 다중 파일 수정 커밋 푸시와 영향 범위 요약 |
| 테스트 추가 | `@claude 이 변경에 대한 Service 단위 테스트 추가해줘` | 새 테스트 파일 작성 + 커밋 푸시와 테스트 시나리오 설명 |
| Javadoc 추가 | `@claude 이 컨트롤러 public 메서드들에 한국어 Javadoc 추가해줘` | 대상 메서드에 Javadoc 추가 후 커밋 푸시 |
| 컨벤션 검사 | `@claude CLAUDE.md 컨벤션 위반 부분 찾아 표시해줘` | 인라인 코멘트로 위반 라인 표시와 어떤 규칙 위반인지 명시 |
| CI 실패 분석 | `@claude 이 PR의 CI 실패 원인 분석해줘` | PR 코멘트: 실패 step, 에러 로그 발췌, 추정 원인, 수정 제안 |
| 머지 충돌 해결 | `@claude dev와 충돌나는 부분 해결해서 푸시해줘` | 충돌 해결 커밋 푸시와 어떻게 해결했는지 설명 |
| 디자이너 이슈에서 1차 PR | `@claude 위 요구사항대로 dev 대상 1차 구현 PR 만들어줘` | 새 브랜치 생성 → 코드 작성 → push → PR open → 원본 이슈에 PR 링크 코멘트 |

---

## 사용 시 주의사항

- **Max 쿼터 1인 공유**: 토큰 발급자 1명의 Claude Max 일/주 한도를 팀이 공유. 무리한 호출 누적 시 일시적으로 동작 막힘 (Slack에 failure 메시지)
- **권한 확장**: `contents: write`로 Claude가 PR 브랜치에 직접 커밋 푸시 가능. 보수적 명령 권장. PR 머지 전 사람 리뷰 필수
- **자동 리뷰 비용**: PR open 시점만 동작하지만 누적되면 비용 큼
- **Slack 노이즈**: 응답마다 백엔드 채널 알림. 노이즈 많으면 `if: steps.claude.outcome == 'success'` 조건으로 조정 가능

---

## 사용 시크릿

- `CLAUDE_CODE_OAUTH_TOKEN` (이미 등록)
- `SLACK_BOT_TOKEN`, `SLACK_BACKEND_CHANNEL_ID` (기존 Slack 워크플로우 재사용)

---

## 머지 후 검증

1. dummy PR 생성 → 자동 리뷰 코멘트 도달 확인
2. dummy PR에 `@claude javadoc 추가해줘` → PR 브랜치에 커밋 푸시 확인
3. dummy PR에 추가 push → 자동 리뷰가 다시 안 도는지 확인 (synchronize 제외 효과)
4. 백엔드 Slack 채널에 알림 도달 확인
5. 팀원 한 명이 dev pull 후 로컬에서 `claude` 실행 → Notion MCP 자동 인식 확인
6. dummy PR 클로즈

---

## 주의사항

이 PR 자체에서는 자동 리뷰가 `Workflow validation failed` 에러로 실패하는 게 정상입니다. 워크플로우 파일을 수정 중인 PR에서 자기 자신을 검토하려고 하면 보안 가드가 동작합니다. 머지 후 다음 PR부터 정상 동작합니다.
