### PR TITLE
DEDU-162 스터디룸 프리뷰 비로그인 파일 다운로드 차단

### DIFF
--- a/src/entities/study-room-preview/infrastructure/preview.dto.ts
+++ b/src/entities/study-room-preview/infrastructure/preview.dto.ts
@@ -56,6 +56,7 @@ const StudyRoomPreviewCoreSchema = z.object({
   subjectType: base.subject,
   schoolInfo: PreviewSchoolInfoSchema,
   enrollmentStatus: z.enum(['OPEN', 'OPERATING']),
+  masked: z.boolean().optional(),
 });
 
 /* ─────────────────────────────────────────────────────

--- a/src/features/mypage/profile/components/edit-description-dialog.tsx
+++ b/src/features/mypage/profile/components/edit-description-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useReducer, useRef, useState } from 'react';
+import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
@@ -21,10 +21,16 @@ import {
 } from '@/shared/components/editor';
 import { Button, Dialog } from '@/shared/components/ui';
 import { classifyMypageError, handleApiError } from '@/shared/lib/errors';
+import { JSONContent } from '@tiptap/react';
 import { Pen } from 'lucide-react';
 
 type EditHighlightDialogProps = {
   description?: FrontendTeacherDescription;
+};
+
+const hasUploadingNode = (node: JSONContent): boolean => {
+  if (node.attrs?.isUploading === true) return true;
+  return (node.content ?? []).some(hasUploadingNode);
 };
 
 export default function EditHighlightDialog({
@@ -107,6 +113,9 @@ export default function EditHighlightDialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dialog.status]);
 
+  // 이미지 업로드 상태
+  const isUploading = useMemo(() => hasUploadingNode(value), [value]);
+
   return (
     <>
       <button
@@ -154,7 +163,11 @@ export default function EditHighlightDialog({
               variant="secondary"
               size="small"
               onClick={handleSave}
-              disabled={updateTeacherDescriptionMutation.isPending || !isDirty}
+              disabled={
+                updateTeacherDescriptionMutation.isPending ||
+                !isDirty ||
+                isUploading
+              }
             >
               저장
             </Button>

--- a/src/features/study-room-preview/components/contents/intro-tab.tsx
+++ b/src/features/study-room-preview/components/contents/intro-tab.tsx
@@ -5,13 +5,14 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
+import { ConfirmDialog } from '@/shared/components/dialog';
 import {
   TextViewer,
   hasMeaningfulEditorContent,
   parseEditorContent,
 } from '@/shared/components/editor';
 import { MiniSpinner } from '@/shared/components/loading';
-import { PRIVATE } from '@/shared/constants';
+import { PRIVATE, PUBLIC } from '@/shared/constants';
 import { cn, getRelativeTimeString } from '@/shared/lib';
 import { trackDedu101StudyroomInfoView } from '@/shared/lib/analytics';
 import { useMemberStore } from '@/store';
@@ -38,6 +39,7 @@ export const StudyroomPreviewIntroTab = ({
   const { data, isPending, isError } = usePreviewMainInfo(studyRoomId);
   const [showPendingSkeleton, setShowPendingSkeleton] = useState(false);
   const [isEditButtonHovered, setIsEditButtonHovered] = useState(false);
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
   const introSectionRef = useRef<HTMLElement | null>(null);
   const curriculumSectionRef = useRef<HTMLElement | null>(null);
   const reviewSectionRef = useRef<HTMLElement | null>(null);
@@ -191,189 +193,212 @@ export const StudyroomPreviewIntroTab = ({
   const classStyle = `${data.modalityKorean} · ${data.classFormKorean} 수업`;
 
   return (
-    <div className="border-line-line1 rounded-tr-xl rounded-b-xl border bg-white p-8">
-      <section className="flex w-full flex-col gap-12">
-        {/* 스터디룸 소개 */}
-        <article
-          data-track-section="intro"
-          ref={introSectionRef}
-          className="bg-system-background-alt flex flex-col gap-4 rounded-xl"
-        >
-          {/* 수정하기 버튼 */}
-          {isMyStudyRoom && (
-            <button
-              type="button"
-              className={cn(
-                'group text-gray-12 border-gray-5 font-label-normal flex h-8.5 w-[107px] cursor-pointer items-center justify-center gap-1 self-end rounded-md border px-2.5 py-1.5 whitespace-nowrap',
-                'hover:border-orange-7 hover:text-orange-7 transition'
-              )}
-              onClick={moveToStudyRoomEditPage}
-              onMouseEnter={() => setIsEditButtonHovered(true)}
-              onMouseLeave={() => setIsEditButtonHovered(false)}
-            >
-              <Image
-                src={'/study-room-preview/ic-pencil.png'}
-                alt="modify"
-                width={24}
-                height={24}
-                className="transition"
-                style={{
-                  filter: isEditButtonHovered
-                    ? 'invert(45%) sepia(64%) saturate(1738%) hue-rotate(352deg) brightness(99%) contrast(97%)'
-                    : 'none',
-                }}
-              />
-              수정하기
-            </button>
-          )}
-          <p className="font-body1-heading tablet:font-headline1-heading text-text-main mb-4">
-            스터디룸 소개
-          </p>
-          <p className="font-body2-normal text-gray-scale-gray-95 break-keep">
-            {data.description || '선생님이 작성한 소개글이 아직 없어요.'}
-          </p>
-        </article>
-
-        {/* 스터디룸 특징 */}
-        {(hasCharacteristic || isMyStudyRoom) && (
-          <article className="bg-system-background-alt flex flex-col rounded-xl">
+    <>
+      <div className="border-line-line1 rounded-tr-xl rounded-b-xl border bg-white p-8">
+        <section className="flex w-full flex-col gap-12">
+          {/* 스터디룸 소개 */}
+          <article
+            data-track-section="intro"
+            ref={introSectionRef}
+            className="bg-system-background-alt flex flex-col gap-4 rounded-xl"
+          >
+            {/* 수정하기 버튼 */}
+            {isMyStudyRoom && (
+              <button
+                type="button"
+                className={cn(
+                  'group text-gray-12 border-gray-5 font-label-normal flex h-8.5 w-[107px] cursor-pointer items-center justify-center gap-1 self-end rounded-md border px-2.5 py-1.5 whitespace-nowrap',
+                  'hover:border-orange-7 hover:text-orange-7 transition'
+                )}
+                onClick={moveToStudyRoomEditPage}
+                onMouseEnter={() => setIsEditButtonHovered(true)}
+                onMouseLeave={() => setIsEditButtonHovered(false)}
+              >
+                <Image
+                  src={'/study-room-preview/ic-pencil.png'}
+                  alt="modify"
+                  width={24}
+                  height={24}
+                  className="transition"
+                  style={{
+                    filter: isEditButtonHovered
+                      ? 'invert(45%) sepia(64%) saturate(1738%) hue-rotate(352deg) brightness(99%) contrast(97%)'
+                      : 'none',
+                  }}
+                />
+                수정하기
+              </button>
+            )}
             <p className="font-body1-heading tablet:font-headline1-heading text-text-main mb-4">
-              스터디룸 특징
+              스터디룸 소개
+            </p>
+            <p className="font-body2-normal text-gray-scale-gray-95 break-keep">
+              {data.description || '선생님이 작성한 소개글이 아직 없어요.'}
+            </p>
+          </article>
+
+          {/* 스터디룸 특징 */}
+          {(hasCharacteristic || isMyStudyRoom) && (
+            <article className="bg-system-background-alt flex flex-col rounded-xl">
+              <p className="font-body1-heading tablet:font-headline1-heading text-text-main mb-4">
+                스터디룸 특징
+              </p>
+
+              {hasCharacteristic ? (
+                <TextViewer
+                  value={parsedContent}
+                  onFileDownloadBlocked={() => setIsLoginModalOpen(true)}
+                />
+              ) : (
+                <div className="flex flex-col items-center justify-center gap-2">
+                  <p className="font-label-normal text-gray-7">
+                    아직 작성된 스터디룸 특징이 없어요.
+                  </p>
+                  <button
+                    className={cn(
+                      'font-body2-normal border-orange-7 text-orange-7 flex h-8.5 w-[107px] cursor-pointer items-center justify-center rounded-md border',
+                      'hover:bg-orange-7/10 transition'
+                    )}
+                    onClick={moveToStudyRoomEditPage}
+                  >
+                    작성하러 가기
+                  </button>
+                </div>
+              )}
+            </article>
+          )}
+
+          {/* 스터디룸 운영 방식 */}
+          <article
+            data-track-section="curriculum"
+            ref={curriculumSectionRef}
+            className="bg-system-background-alt flex flex-col gap-1 rounded-xl"
+          >
+            <p className="font-body1-heading tablet:font-headline1-heading text-text-main mb-4">
+              스터디룸 운영 방식
+            </p>
+            <div className="tablet:flex-row tablet:items-stretch tablet:gap-5 flex flex-col gap-4">
+              <InfoItem
+                icon="/study-room-preview/ic-books.png"
+                alt="subject"
+                label="과목"
+                value={data.subjectTypeKorean}
+              />
+
+              <div className="tablet:block bg-gray-3 hidden w-px self-stretch" />
+
+              <InfoItem
+                icon="/study-room-preview/ic-person.png"
+                alt="target"
+                label="수업 대상"
+                value={targetText}
+              />
+
+              <div className="tablet:block bg-gray-3 hidden w-px self-stretch" />
+
+              <InfoItem
+                icon="/study-room-preview/ic-book.png"
+                alt="class-type"
+                label="수업 방식"
+                value={classStyle}
+              />
+            </div>
+          </article>
+
+          {/* 스터디룸 후기 */}
+          <article
+            data-track-section="review"
+            ref={reviewSectionRef}
+            className="bg-system-background-alt flex flex-col gap-4 rounded-xl"
+          >
+            <p className="font-body1-heading tablet:font-headline1-heading text-text-main mb-4">
+              스터디룸 후기
             </p>
 
-            {hasCharacteristic ? (
-              <TextViewer value={parsedContent} />
-            ) : (
-              <div className="flex flex-col items-center justify-center gap-2">
-                <p className="font-label-normal text-gray-7">
-                  아직 작성된 스터디룸 특징이 없어요.
-                </p>
-                <button
-                  className={cn(
-                    'font-body2-normal border-orange-7 text-orange-7 flex h-8.5 w-[107px] cursor-pointer items-center justify-center rounded-md border',
-                    'hover:bg-orange-7/10 transition'
-                  )}
-                  onClick={moveToStudyRoomEditPage}
-                >
-                  작성하러 가기
-                </button>
-              </div>
-            )}
-          </article>
-        )}
+            {hasReviews ? (
+              <>
+                <div className="desktop:flex-row desktop:items-center desktop:justify-between flex flex-col gap-3">
+                  <div className="flex items-center gap-2 overflow-x-auto whitespace-nowrap">
+                    {REVIEW_TAGS.map((tag) => (
+                      <div
+                        key={tag}
+                        className="font-label-heading bg-orange-2 text-orange-7 rounded-xl px-4 py-2"
+                      >
+                        {tag}
+                      </div>
+                    ))}
+                  </div>
+                  <p className="font-label-normal text-orange-7">
+                    {reviews.length}개의 후기
+                  </p>
+                </div>
 
-        {/* 스터디룸 운영 방식 */}
-        <article
-          data-track-section="curriculum"
-          ref={curriculumSectionRef}
-          className="bg-system-background-alt flex flex-col gap-1 rounded-xl"
-        >
-          <p className="font-body1-heading tablet:font-headline1-heading text-text-main mb-4">
-            스터디룸 운영 방식
-          </p>
-          <div className="tablet:flex-row tablet:items-stretch tablet:gap-5 flex flex-col gap-4">
-            <InfoItem
-              icon="/study-room-preview/ic-books.png"
-              alt="subject"
-              label="과목"
-              value={data.subjectTypeKorean}
-            />
-
-            <div className="tablet:block bg-gray-3 hidden w-px self-stretch" />
-
-            <InfoItem
-              icon="/study-room-preview/ic-person.png"
-              alt="target"
-              label="수업 대상"
-              value={targetText}
-            />
-
-            <div className="tablet:block bg-gray-3 hidden w-px self-stretch" />
-
-            <InfoItem
-              icon="/study-room-preview/ic-book.png"
-              alt="class-type"
-              label="수업 방식"
-              value={classStyle}
-            />
-          </div>
-        </article>
-
-        {/* 스터디룸 후기 */}
-        <article
-          data-track-section="review"
-          ref={reviewSectionRef}
-          className="bg-system-background-alt flex flex-col gap-4 rounded-xl"
-        >
-          <p className="font-body1-heading tablet:font-headline1-heading text-text-main mb-4">
-            스터디룸 후기
-          </p>
-
-          {hasReviews ? (
-            <>
-              <div className="desktop:flex-row desktop:items-center desktop:justify-between flex flex-col gap-3">
-                <div className="flex items-center gap-2 overflow-x-auto whitespace-nowrap">
-                  {REVIEW_TAGS.map((tag) => (
+                <div className="flex flex-col gap-3 pr-2">
+                  {reviews.map((review) => (
                     <div
-                      key={tag}
-                      className="font-label-heading bg-orange-2 text-orange-7 rounded-xl px-4 py-2"
+                      key={review.id}
+                      className="border-gray-3 bg-system-background-alt flex flex-col gap-3 rounded-lg border p-4"
                     >
-                      {tag}
+                      <div className="flex items-start gap-3">
+                        <Image
+                          src="/character/img_profile_student01.png"
+                          alt="student"
+                          width={36}
+                          height={36}
+                          className="border-gray-12 h-9 w-9 rounded-full border object-cover p-0.5"
+                        />
+                        <div className="flex flex-1 flex-col gap-1">
+                          <div className="flex items-center justify-between">
+                            <p className="font-body2-normal text-text-main">
+                              {review.srcMemberName}
+                            </p>
+                            <p className="font-caption-normal text-gray-7">
+                              {getRelativeTimeString(review.regDate)}
+                            </p>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <p className="font-caption-normal text-orange-7">
+                              학생
+                            </p>
+                            <p className="font-caption-normal text-gray-12">
+                              {review.startDate}부터 수업 중
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                      <p className="font-label-normal text-text-sub1 break-keep">
+                        {review.content}
+                      </p>
                     </div>
                   ))}
                 </div>
-                <p className="font-label-normal text-orange-7">
-                  {reviews.length}개의 후기
-                </p>
-              </div>
+              </>
+            ) : (
+              <p className="font-label-normal text-gray-7">
+                아직 작성된 후기가 없습니다.
+              </p>
+            )}
+          </article>
+        </section>
+      </div>
 
-              <div className="flex flex-col gap-3 pr-2">
-                {reviews.map((review) => (
-                  <div
-                    key={review.id}
-                    className="border-gray-3 bg-system-background-alt flex flex-col gap-3 rounded-lg border p-4"
-                  >
-                    <div className="flex items-start gap-3">
-                      <Image
-                        src="/character/img_profile_student01.png"
-                        alt="student"
-                        width={36}
-                        height={36}
-                        className="border-gray-12 h-9 w-9 rounded-full border object-cover p-0.5"
-                      />
-                      <div className="flex flex-1 flex-col gap-1">
-                        <div className="flex items-center justify-between">
-                          <p className="font-body2-normal text-text-main">
-                            {review.srcMemberName}
-                          </p>
-                          <p className="font-caption-normal text-gray-7">
-                            {getRelativeTimeString(review.regDate)}
-                          </p>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <p className="font-caption-normal text-orange-7">
-                            학생
-                          </p>
-                          <p className="font-caption-normal text-gray-12">
-                            {review.startDate}부터 수업 중
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-                    <p className="font-label-normal text-text-sub1 break-keep">
-                      {review.content}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            </>
-          ) : (
-            <p className="font-label-normal text-gray-7">
-              아직 작성된 후기가 없습니다.
-            </p>
-          )}
-        </article>
-      </section>
-    </div>
+      <ConfirmDialog
+        variant="confirm-cancel"
+        open={isLoginModalOpen}
+        dispatch={(action) => {
+          if (action.type === 'CLOSE') setIsLoginModalOpen(false);
+        }}
+        emphasis="title-strong"
+        onConfirm={() => {
+          const from = encodeURIComponent(window.location.pathname);
+          router.replace(`${PUBLIC.CORE.LOGIN}?from=${from}`);
+        }}
+        onCancel={() => setIsLoginModalOpen(false)}
+        title="로그인이 필요해요"
+        description="파일을 다운로드하려면 로그인이 필요해요."
+        confirmText="로그인하기"
+        cancelText="취소"
+      />
+    </>
   );
 };

--- a/src/features/study-room-preview/components/contents/intro-tab.tsx
+++ b/src/features/study-room-preview/components/contents/intro-tab.tsx
@@ -248,6 +248,7 @@ export const StudyroomPreviewIntroTab = ({
                 <TextViewer
                   value={parsedContent}
                   onFileDownloadBlocked={() => setIsLoginModalOpen(true)}
+                  blockFileDownload={!member}
                 />
               ) : (
                 <div className="flex flex-col items-center justify-center gap-2">

--- a/src/features/study-rooms/components/create/study-room-flow.tsx
+++ b/src/features/study-rooms/components/create/study-room-flow.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { FieldPath, FormProvider, useForm } from 'react-hook-form';
 
 import { useRouter } from 'next/navigation';
@@ -48,6 +48,7 @@ import { classifyPreviewError, handleApiError } from '@/shared/lib/errors';
 import { useMemberStore } from '@/store';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { JSONContent } from '@tiptap/react';
 
 import { useUpdateStudyRoom } from '../sidebar/services/query';
 
@@ -87,6 +88,11 @@ export const fieldsPerStep: Record<Step, FieldPath<StudyRoomFormValues>[]> = {
     'schoolInfo.schoolLevel',
     'schoolInfo.grade',
   ],
+};
+
+const hasUploadingNode = (node: JSONContent): boolean => {
+  if (node.attrs?.isUploading === true) return true;
+  return (node.content ?? []).some(hasUploadingNode);
 };
 
 export default function StudyRoomFlow({
@@ -307,6 +313,12 @@ export default function StudyRoomFlow({
     router,
   ]);
 
+  const characteristic = methods.watch('characteristic');
+  const isCharacteristicUploading = useMemo(
+    () => hasUploadingNode(characteristic),
+    [characteristic]
+  );
+
   return (
     <section className="flex flex-col">
       <div className="mx-auto w-fit">
@@ -333,7 +345,7 @@ export default function StudyRoomFlow({
             <StepOne
               mode={mode}
               onNext={handleNext}
-              disabled={!isStepValid || isMutating}
+              disabled={!isStepValid || isMutating || isCharacteristicUploading}
               canSubmitEdit={canSubmitEdit}
               onCancel={handleCancel}
               onRequestEdit={() =>

--- a/src/shared/components/editor/model/editor-viewer-context.ts
+++ b/src/shared/components/editor/model/editor-viewer-context.ts
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react';
+
+type EditorViewerContextValue = {
+  onLoginRequired?: () => void;
+};
+
+export const EditorViewerContext = createContext<EditorViewerContextValue>({});
+
+export const useEditorViewerContext = () => useContext(EditorViewerContext);

--- a/src/shared/components/editor/model/editor-viewer-context.ts
+++ b/src/shared/components/editor/model/editor-viewer-context.ts
@@ -2,6 +2,7 @@ import { createContext, useContext } from 'react';
 
 type EditorViewerContextValue = {
   onLoginRequired?: () => void;
+  shouldBlockDownload?: boolean;
 };
 
 export const EditorViewerContext = createContext<EditorViewerContextValue>({});

--- a/src/shared/components/editor/types/index.ts
+++ b/src/shared/components/editor/types/index.ts
@@ -19,6 +19,7 @@ export type TextEditorProps = {
 export type TextViewerProps = {
   className?: string;
   value: TextEditorValue;
+  onFileDownloadBlocked?: () => void;
 };
 
 /** 툴바 Props */

--- a/src/shared/components/editor/types/index.ts
+++ b/src/shared/components/editor/types/index.ts
@@ -20,6 +20,7 @@ export type TextViewerProps = {
   className?: string;
   value: TextEditorValue;
   onFileDownloadBlocked?: () => void;
+  blockFileDownload?: boolean;
 };
 
 /** 툴바 Props */

--- a/src/shared/components/editor/ui/file-attachment-node.tsx
+++ b/src/shared/components/editor/ui/file-attachment-node.tsx
@@ -1,11 +1,13 @@
 'use client';
 
+import { useEditorViewerContext } from '@/shared/components/editor/model/editor-viewer-context';
 import { NodeViewProps, NodeViewWrapper } from '@tiptap/react';
 import {
   Download,
   FileArchive,
   FileSpreadsheet,
   FileText,
+  Lock,
   Presentation,
 } from 'lucide-react';
 
@@ -35,13 +37,21 @@ const getFileIcon = (filename: string) => {
 
 export const FileAttachmentNode = ({ node }: NodeViewProps) => {
   const { url, name, size, isUploading } = node.attrs as {
-    url: string;
+    url: string | null;
     name: string;
     size: number;
     isUploading?: boolean;
   };
 
+  const { onLoginRequired } = useEditorViewerContext();
+  const isMasked = !url && !isUploading;
+
   const handleDownload = () => {
+    if (!url) {
+      onLoginRequired?.();
+      return;
+    }
+
     const link = document.createElement('a');
     link.href = url;
     link.download = name;
@@ -76,11 +86,16 @@ export const FileAttachmentNode = ({ node }: NodeViewProps) => {
             type="button"
             onClick={handleDownload}
             className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-200 hover:text-gray-700 dark:hover:bg-gray-600 dark:hover:text-gray-300"
-            title="다운로드"
+            title={isMasked ? '로그인 후 다운로드 가능' : '다운로드'}
           >
-            <Download className="h-4 w-4" />
+            {isMasked ? (
+              <Lock className="h-4 w-4" />
+            ) : (
+              <Download className="h-4 w-4" />
+            )}
           </button>
         )}
+
         {isUploading && (
           <div className="flex h-8 w-8 shrink-0 items-center justify-center">
             <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600" />

--- a/src/shared/components/editor/ui/file-attachment-node.tsx
+++ b/src/shared/components/editor/ui/file-attachment-node.tsx
@@ -43,11 +43,11 @@ export const FileAttachmentNode = ({ node }: NodeViewProps) => {
     isUploading?: boolean;
   };
 
-  const { onLoginRequired } = useEditorViewerContext();
-  const isMasked = !url && !isUploading;
+  const { onLoginRequired, shouldBlockDownload } = useEditorViewerContext();
+  const isMasked = (!url || shouldBlockDownload) && !isUploading;
 
   const handleDownload = () => {
-    if (!url) {
+    if (!url || shouldBlockDownload) {
       onLoginRequired?.();
       return;
     }

--- a/src/shared/components/editor/ui/text-viewer.tsx
+++ b/src/shared/components/editor/ui/text-viewer.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 
+import { EditorViewerContext } from '@/shared/components/editor/model/editor-viewer-context';
 import { createNotionExtensions } from '@/shared/components/editor/model/extensions';
 import { TextViewerProps } from '@/shared/components/editor/types';
 import { cn } from '@/shared/lib';
@@ -15,7 +16,11 @@ const viewerExtensions = createNotionExtensions({
   enableSlashCommand: false,
 });
 
-export const TextViewer = ({ className, value }: TextViewerProps) => {
+export const TextViewer = ({
+  className,
+  value,
+  onFileDownloadBlocked,
+}: TextViewerProps) => {
   const editor = useEditor({
     extensions: viewerExtensions,
     content: value,
@@ -34,5 +39,11 @@ export const TextViewer = ({ className, value }: TextViewerProps) => {
     editor.commands.setContent(value);
   }, [editor, value]);
 
-  return <EditorContent editor={editor} />;
+  return (
+    <EditorViewerContext.Provider
+      value={{ onLoginRequired: onFileDownloadBlocked }}
+    >
+      <EditorContent editor={editor} />
+    </EditorViewerContext.Provider>
+  );
 };

--- a/src/shared/components/editor/ui/text-viewer.tsx
+++ b/src/shared/components/editor/ui/text-viewer.tsx
@@ -20,6 +20,7 @@ export const TextViewer = ({
   className,
   value,
   onFileDownloadBlocked,
+  blockFileDownload,
 }: TextViewerProps) => {
   const editor = useEditor({
     extensions: viewerExtensions,
@@ -41,7 +42,10 @@ export const TextViewer = ({
 
   return (
     <EditorViewerContext.Provider
-      value={{ onLoginRequired: onFileDownloadBlocked }}
+      value={{
+        onLoginRequired: onFileDownloadBlocked,
+        shouldBlockDownload: blockFileDownload,
+      }}
     >
       <EditorContent editor={editor} />
     </EditorViewerContext.Provider>

--- a/svgr.d.ts
+++ b/svgr.d.ts
@@ -3,3 +3,4 @@ declare module '*.svg' {
   const content: FC<SVGProps<SVGElement>>;
   export default content;
 }
+declare module '*.css';


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
<!-- 
- 변경된 내용에 대해 간략하게 설명해주세요.
- 예: 사용자 로그인 기능 추가
- 예: API 응답 구조 변경 
-->
- 비로그인 사용자가 스터디룸 프리뷰에서 파일 다운로드 시도 시 로그인 유도 모달 표시
- Tiptap NodeView에 콜백 주입을 위해 EditorViewerContext(React Context) 도입
- 파일/이미지 업로드 완료 전 저장 버튼 비활성화 (스터디룸 수정 폼, 선생님 특징 편집)

백엔드 `masked` 필드 작업 전, 프론트에서 임시 차단 처리해놨습니다(590bd726). 백엔드 작업 완료 후 해당 커밋 revert할 예정입니다.

### 테스트
- [ ] 비로그인 상태에서 프리뷰 파일 다운로드 클릭 → 로그인 모달 노출 확인                                                      
- [ ] 로그인 상태에서 파일 다운로드 정상 동작 확인                                                                             
- [ ] 스터디룸 수정 폼에서 파일 업로드 중 다음/수정하기 버튼 비활성화 확인
- [ ] 선생님 특징 편집에서 파일 업로드 중 저장 버튼 비활성화 확인

## 🧐 관련 이슈
<!--
- 관련된 이슈 번호를 적어주세요. (ex. `Closes #123`, `Fixes #456`) 
-->

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->
<img width="583" height="163" alt="image" src="https://github.com/user-attachments/assets/55002c08-4da1-4803-aecf-de3c48f9cadc" />
<img width="511" height="222" alt="image" src="https://github.com/user-attachments/assets/05ac5618-9773-430b-8f31-ca98983267fb" />


## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
