### PR TITLE
feat: 헤더 '탐색하기' 버튼 텍스트를 '멋있게 탐색하기'로 변경

### DIFF
--- a/src/layout/header.tsx
+++ b/src/layout/header.tsx
@@ -119,7 +119,7 @@ export const Header = () => {
                     : 'hover:bg-gray-11'
                 )}
               >
-                탐색하기
+                멋있게 탐색하기
               </Link>
               <Link
                 href={PUBLIC.COMMUNITY.COLUMN.LIST}
@@ -272,7 +272,7 @@ export const Header = () => {
                     onClick={() => setIsOpen(false)}
                   >
                     <FindingIcon />
-                    <span>탐색하기</span>
+                    <span>멋있게 탐색하기</span>
                   </PopoverLink>
 
                   <PopoverSeparator />

--- a/src/layout/header.tsx
+++ b/src/layout/header.tsx
@@ -119,7 +119,7 @@ export const Header = () => {
                     : 'hover:bg-gray-11'
                 )}
               >
-                멋있게 탐색하기
+                간지나게 탐색하기
               </Link>
               <Link
                 href={PUBLIC.COMMUNITY.COLUMN.LIST}
@@ -272,7 +272,7 @@ export const Header = () => {
                     onClick={() => setIsOpen(false)}
                   >
                     <FindingIcon />
-                    <span>멋있게 탐색하기</span>
+                    <span>간지나게 탐색하기</span>
                   </PopoverLink>
 
                   <PopoverSeparator />


### PR DESCRIPTION
헤더의 '탐색하기' 버튼 텍스트를 '멋있게 탐색하기'로 변경합니다.

Closes #331

Generated with [Claude Code](https://claude.ai/code)