### PR TITLE
BTS-727 /api/v1/public/ 경로 미들웨어 인증 가드 제외

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -96,6 +96,11 @@ export function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
+  // 백엔드 공개 API 경로는 인증 없이 통과 (BFF에서 쿠키는 자동으로 붙음)
+  if (pathname.startsWith('/api/v1/public/')) {
+    return NextResponse.next();
+  }
+
   // 인증 가드
   return handleAuthGuard(req);
 }


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
<!-- 
- 변경된 내용에 대해 간략하게 설명해주세요.
- 예: 사용자 로그인 기능 추가
- 예: API 응답 구조 변경 
-->
배경:                                                                                                                     
  - 문의 목록은 누구나 볼 수 있는 공개 API지만, 로그인한 사용자는 본인이 작성한 글인지 여부(isWrittenByMe)를 확인해야 합니다.
  - 백엔드가 이를 판단하려면 요청에 인증 쿠키가 포함되어야 해서 api.private로 변경했습니다. (PR #334)                         
   
문제:                                                                                                                     
  - api.private는 백엔드에 직접 요청하지 않고 BFF(/api/v1/...)를 경유합니다. 
  - 그런데 미들웨어에서 /api/:path* 전체에 인증 가드가 걸려 있어, 비로그인 상태에서 해당 경로에 접근하면 307 redirect가 발생했습니다.                                     
   
수정:                                                                                                                     
  - /api/v1/public/ 경로는 백엔드 자체가 공개 엔드포인트이므로 미들웨어 인증 가드를 건너뛰도록 수정했습니다. 
  - 로그인 상태라면 BFF가 쿠키를 자동으로 포함해 요청합니다.    

  
## 🧐 관련 이슈
<!--
- 관련된 이슈 번호를 적어주세요. (ex. `Closes #123`, `Fixes #456`) 
-->
BTS-727

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->
<img width="280" height="152" alt="image" src="https://github.com/user-attachments/assets/f3c1c4b9-bda3-442c-a37a-9504337ee8fd" />


## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
