### PR TITLE
BTS-696 칼럼 좋아요 기능 추가

### DIFF
--- a/src/app/(home)/community/column/[id]/page.tsx
+++ b/src/app/(home)/community/column/[id]/page.tsx
@@ -9,6 +9,7 @@ import { repository } from '@/entities/column';
 import ColumnDetailView from '@/features/community/column/components/column-detail-view';
 import { generateColumnDetailMetadata } from '@/features/community/column/metadata';
 import BackLink from '@/features/dashboard/studynote/components/back-link';
+import { isAxiosError } from 'axios';
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -30,8 +31,9 @@ export async function generateMetadata({
     const origin = await getRequestOrigin();
     const columnDetail = await getDetail(Number(id));
     return generateColumnDetailMetadata(columnDetail, origin);
-  } catch {
-    notFound();
+  } catch (error) {
+    if (isAxiosError(error) && error.response?.status === 404) notFound();
+    return { title: SITE_CONFIG.name };
   }
 }
 

--- a/src/app/(home)/community/column/[id]/page.tsx
+++ b/src/app/(home)/community/column/[id]/page.tsx
@@ -31,7 +31,7 @@ export async function generateMetadata({
     const columnDetail = await getDetail(Number(id));
     return generateColumnDetailMetadata(columnDetail, origin);
   } catch {
-    return { title: SITE_CONFIG.name };
+    notFound();
   }
 }
 
@@ -47,24 +47,17 @@ export default async function ColumnDetailPage({
 
   if (isNaN(columnId)) notFound();
 
-  try {
-    const data = isPrivate ? undefined : await getDetail(columnId);
-
-    return (
-      <div className="mx-auto max-w-[1440px] pt-8 pb-20 lg:px-20">
-        <BackLink />
-        <div className="border-line-line1 mt-4 h-fit w-full rounded-xl border bg-white px-8 py-10">
-          <ColumnDetailView
-            id={columnId}
-            initialData={data}
-            isPrivate={isPrivate}
-          />
-        </div>
+  return (
+    <div className="mx-auto max-w-[1440px] pt-8 pb-20 lg:px-20">
+      <BackLink />
+      <div className="border-line-line1 mt-4 h-fit w-full rounded-xl border bg-white px-8 py-10">
+        <ColumnDetailView
+          id={columnId}
+          isPrivate={isPrivate}
+        />
       </div>
-    );
-  } catch {
-    notFound();
-  }
+    </div>
+  );
 }
 
 const getRequestOrigin = async () => {

--- a/src/entities/column/infrastructure/column.dto.ts
+++ b/src/entities/column/infrastructure/column.dto.ts
@@ -11,6 +11,7 @@ const ColumnListItemDtoSchema = z.object({
   tags: z.array(z.string()),
   thumbnailUrl: z.string().nullable(),
   viewCount: z.number(),
+  likeCount: z.number(),
   regDate: z.string(),
 });
 
@@ -38,6 +39,8 @@ const ColumnDetailDtoSchema = z.object({
     expiresAt: z.string().nullable(),
   }),
   viewCount: z.number(),
+  likeCount: z.number(),
+  liked: z.boolean().nullable(),
   regDate: z.string(),
   modDate: z.string(),
 });
@@ -52,6 +55,7 @@ const MyColumnListItemDtoSchema = z.object({
   status: z.enum(['PENDING_APPROVAL', 'APPROVED']),
   thumbnailUrl: z.string().nullable(),
   viewCount: z.number(),
+  likeCount: z.number(),
   regDate: z.string(),
   modDate: z.string(),
 });
@@ -76,6 +80,7 @@ const AdminColumnListItemDtoSchema = z.object({
   status: z.enum(['PENDING_APPROVAL', 'APPROVED']),
   thumbnailUrl: z.string().nullable(),
   viewCount: z.number(),
+  likeCount: z.number(),
   regDate: z.string(),
   modDate: z.string(),
 });
@@ -86,6 +91,14 @@ const AdminColumnPageDtoSchema = z.object({
   totalElements: z.number(),
   totalPages: z.number(),
   content: z.array(AdminColumnListItemDtoSchema),
+});
+
+/* ─────────────────────────────────────────────────────
+ * 좋아요 토클 응답 스키마
+ * ────────────────────────────────────────────────────*/
+const LikeToggleDtoSchema = z.object({
+  liked: z.boolean().nullable(),
+  likeCount: z.number(),
 });
 
 /* ─────────────────────────────────────────────────────
@@ -124,6 +137,7 @@ export const dto = {
   myPage: MyColumnPageDtoSchema,
   adminListItem: AdminColumnListItemDtoSchema,
   adminPage: AdminColumnPageDtoSchema,
+  likeToggle: LikeToggleDtoSchema,
 };
 
 export const payload = {

--- a/src/entities/column/infrastructure/column.repository.ts
+++ b/src/entities/column/infrastructure/column.repository.ts
@@ -23,10 +23,18 @@ const getColumnList = async (params: {
 };
 
 /* ─────────────────────────────────────────────────────
- * [READ] 칼럼 상세 조회 (공개)
+ * [READ] 칼럼 상세 조회 - SEO용 (비인증, liked 미포함)
  * ────────────────────────────────────────────────────*/
 const getColumnDetail = async (id: number) => {
   const response = await api.public.get(`/public/column-articles/${id}`);
+  return unwrapEnvelope(response, dto.detail);
+};
+
+/* ─────────────────────────────────────────────────────
+ * [READ] 칼럼 상세 조회 - 렌더링용 (인증, liked 포함)
+ * ────────────────────────────────────────────────────*/
+const getColumnDetailWithAuth = async (id: number) => {
+  const response = await api.private.get(`/public/column-articles/${id}`);
   return unwrapEnvelope(response, dto.detail);
 };
 
@@ -139,6 +147,7 @@ const toggleColumnLike = async (id: number) => {
 export const repository = {
   getColumnList,
   getColumnDetail,
+  getColumnDetailWithAuth,
   createColumn,
   updateColumn,
   deleteColumn,

--- a/src/entities/column/infrastructure/column.repository.ts
+++ b/src/entities/column/infrastructure/column.repository.ts
@@ -126,6 +126,14 @@ const approveColumn = async (id: number) => {
 };
 
 /* ─────────────────────────────────────────────────────
+ * [PATCH] 칼럼 좋아요 토글 (본인 글 제외)
+ * ────────────────────────────────────────────────────*/
+const toggleColumnLike = async (id: number) => {
+  const response = await api.private.patch(`/common/column-articles/${id}`);
+  return unwrapEnvelope(response, dto.likeToggle);
+};
+
+/* ─────────────────────────────────────────────────────
  * 내보내기
  * ────────────────────────────────────────────────────*/
 export const repository = {
@@ -139,4 +147,5 @@ export const repository = {
   getAdminColumnList,
   getAdminColumnDetail,
   approveColumn,
+  toggleColumnLike,
 };

--- a/src/features/community/column/components/admin-column-detail-view.tsx
+++ b/src/features/community/column/components/admin-column-detail-view.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import DeleteColumnDialog from '@/features/community/column/components/delete-column-dialog';
@@ -11,10 +12,11 @@ import {
 } from '@/features/community/column/hooks/use-admin-column';
 import { useDeleteColumn } from '@/features/community/column/hooks/use-column-form';
 import { TextViewer, parseEditorContent } from '@/shared/components/editor';
-import { Button } from '@/shared/components/ui';
-import { PRIVATE } from '@/shared/constants';
+import { Button, StatusBadge } from '@/shared/components/ui';
+import { PRIVATE, PUBLIC } from '@/shared/constants';
 import { getRelativeTimeString } from '@/shared/lib';
 import { classifyColumnError, handleApiError } from '@/shared/lib/errors';
+import { ExternalLink } from 'lucide-react';
 
 export default function AdminColumnDetailView({
   id,
@@ -71,11 +73,28 @@ export default function AdminColumnDetailView({
   return (
     <>
       <article>
-        {isPending && (
-          <div className="bg-gray-1 font-label-normal mb-6 rounded-lg py-3 text-center">
-            승인 대기 중인 글입니다.
+        <div className="mb-4 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <StatusBadge
+              variant="default"
+              label="콘텐츠 검토"
+            />
+            <StatusBadge
+              variant={isPending ? 'warning' : 'success'}
+              label={isPending ? '승인 대기' : '게시 중'}
+            />
           </div>
-        )}
+          {!isPending && (
+            <Link
+              href={PUBLIC.COMMUNITY.COLUMN.DETAIL(id)}
+              className="text-gray-7 hover:text-gray-10 flex items-center gap-1 hover:underline"
+            >
+              게시글 바로가기
+              <ExternalLink size={14} />
+            </Link>
+          )}
+        </div>
+
         <div className="mb-6 flex items-start justify-between gap-4">
           <h1 className="font-title-heading">{data.title}</h1>
           <div className="flex shrink-0 items-center gap-2">
@@ -100,6 +119,7 @@ export default function AdminColumnDetailView({
           <span>{data.authorName ?? data.authorNickname ?? '알 수 없음'}</span>
           <span>{getRelativeTimeString(data.regDate)}</span>
           <span>조회 {data.viewCount}</span>
+          <span>좋아요 {data.likeCount}</span>
         </div>
         <div className="mb-6 flex flex-wrap gap-2">
           {data.tags.map((tag) => (

--- a/src/features/community/column/components/admin-column-table.tsx
+++ b/src/features/community/column/components/admin-column-table.tsx
@@ -81,6 +81,8 @@ export default function AdminColumnTable() {
                 <th>제목</th>
                 <th>작성자</th>
                 <th>상태</th>
+                <th>조회수</th>
+                <th>좋아요</th>
                 <th>작성일</th>
                 <th>관리</th>
               </tr>
@@ -115,6 +117,8 @@ export default function AdminColumnTable() {
                         {status.label}
                       </span>
                     </td>
+                    <td className="px-5 py-4">{column.viewCount}</td>
+                    <td className="px-5 py-4">{column.likeCount}</td>
                     <td className="px-5 py-4">
                       {column.regDate.split('T')[0]}
                     </td>

--- a/src/features/community/column/components/column-card.tsx
+++ b/src/features/community/column/components/column-card.tsx
@@ -5,7 +5,7 @@ import { ColumnListItem } from '@/entities/column';
 import { PUBLIC } from '@/shared/constants';
 import { formatDistanceToNow } from 'date-fns';
 import { ko } from 'date-fns/locale';
-import { Eye } from 'lucide-react';
+import { Eye, Heart } from 'lucide-react';
 
 export default function ColumnCard({ column }: { column: ColumnListItem }) {
   return (
@@ -25,15 +25,30 @@ export default function ColumnCard({ column }: { column: ColumnListItem }) {
             className="rounded-t-xl object-cover"
           />
         )}
-        <div className="bg-gray-12/40 absolute top-4 right-4 flex items-center gap-1 rounded-lg px-2.5 py-1.5">
-          <Eye
-            width={16}
-            color="var(--color-gray-white)"
-            aria-label="조회수"
-          />
-          <span className="font-label-normal text-gray-white">
-            {column.viewCount}
-          </span>
+        <div className="bg-gray-12/40 absolute top-4 right-4 flex gap-2 rounded-lg px-2.5 py-1.5">
+          <div className="flex items-center gap-1">
+            <Eye
+              width={16}
+              color="var(--color-gray-white)"
+              aria-label="조회수"
+            />
+            <span className="font-label-normal text-gray-white">
+              {column.viewCount}
+            </span>
+          </div>
+
+          {column.likeCount > 0 && (
+            <div className="flex items-center gap-1">
+              <Heart
+                width={16}
+                color="var(--color-gray-white)"
+                aria-label="좋아요"
+              />
+              <span className="font-label-normal text-gray-white">
+                {column.likeCount}
+              </span>
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/features/community/column/components/column-detail-view.tsx
+++ b/src/features/community/column/components/column-detail-view.tsx
@@ -1,14 +1,21 @@
 'use client';
 
+import { useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
 import { ColumnDetail } from '@/entities/column';
 import {
   useColumnDetail,
   useMyColumnDetail,
   useToggleColumnLike,
 } from '@/features/community/column/hooks/use-column-detail';
+import { ConfirmDialog } from '@/shared/components/dialog';
 import { TextViewer, parseEditorContent } from '@/shared/components/editor';
+import { PUBLIC } from '@/shared/constants';
 import { getRelativeTimeString } from '@/shared/lib';
 import { classifyColumnError, handleApiError } from '@/shared/lib/errors';
+import { useMemberStore } from '@/store';
 import { Heart } from 'lucide-react';
 
 export default function ColumnDetailView({
@@ -20,6 +27,9 @@ export default function ColumnDetailView({
   initialData?: ColumnDetail;
   isPrivate?: boolean;
 }) {
+  const router = useRouter();
+  const member = useMemberStore((s) => s.member);
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
   const {
     data: publicData,
     isLoading: publicLoading,
@@ -44,6 +54,11 @@ export default function ColumnDetailView({
   const content = parseEditorContent(data.resolvedContent.content);
 
   const handleLikeToggle = () => {
+    if (!member) {
+      setIsLoginModalOpen(true);
+      return;
+    }
+
     toggleColumnLikeMutation.mutate(undefined, {
       onError: (error) => {
         handleApiError(error, classifyColumnError, {
@@ -54,51 +69,72 @@ export default function ColumnDetailView({
   };
 
   return (
-    <article>
-      {isPrivate && (
-        <div className="bg-gray-1 font-label-normal mb-6 rounded-lg py-3 text-center">
-          승인 대기 중인 글입니다.
+    <>
+      <article>
+        {isPrivate && (
+          <div className="bg-gray-1 font-label-normal mb-6 rounded-lg py-3 text-center">
+            승인 대기 중인 글입니다.
+          </div>
+        )}
+        <h1 className="font-title-heading mb-4">{data.title}</h1>
+        <div className="text-text-sub2 font-label-normal mb-6 flex gap-4">
+          <span>{data.authorName ?? data.authorNickname ?? '알 수 없음'}</span>
+          <span>{getRelativeTimeString(data.regDate)}</span>
+          <span>조회 {data.viewCount}</span>
+          <span>좋아요 {data.likeCount}</span>
         </div>
-      )}
-      <h1 className="font-title-heading mb-4">{data.title}</h1>
-      <div className="text-text-sub2 font-label-normal mb-6 flex gap-4">
-        <span>{data.authorName ?? data.authorNickname ?? '알 수 없음'}</span>
-        <span>{getRelativeTimeString(data.regDate)}</span>
-        <span>조회 {data.viewCount}</span>
-        <span>좋아요 {data.likeCount}</span>
-      </div>
-      <div className="mb-6 flex flex-wrap gap-2">
-        {data.tags.map((tag) => (
-          <span
-            key={tag}
-            className="bg-orange-2 font-label-normal rounded-lg px-3 py-1"
-          >
-            # {tag}
-          </span>
-        ))}
-      </div>
-      <TextViewer value={content} />
+        <div className="mb-6 flex flex-wrap gap-2">
+          {data.tags.map((tag) => (
+            <span
+              key={tag}
+              className="bg-orange-2 font-label-normal rounded-lg px-3 py-1"
+            >
+              # {tag}
+            </span>
+          ))}
+        </div>
+        <TextViewer value={content} />
 
-      {/* 좋아요 버튼 */}
-      {!isPrivate && (
-        <div className="mt-10 flex justify-center">
-          <button
-            onClick={handleLikeToggle}
-            disabled={toggleColumnLikeMutation.isPending}
-            className="border-line-line1 hover:bg-background-orange flex cursor-pointer items-center gap-1.5 rounded-full border px-8 py-2 transition-colors"
-          >
-            <Heart
-              size={28}
-              className={
-                data.liked === true
-                  ? 'fill-orange-5 text-orange-5'
-                  : 'text-gray-5'
-              }
-            />
-            <span className="text-gray-5">{data.likeCount}</span>
-          </button>
-        </div>
-      )}
-    </article>
+        {/* 좋아요 버튼 */}
+        {!isPrivate && (
+          <div className="mt-10 flex justify-center">
+            <button
+              onClick={handleLikeToggle}
+              disabled={toggleColumnLikeMutation.isPending}
+              className="border-line-line1 hover:bg-background-orange flex cursor-pointer items-center gap-1.5 rounded-full border px-8 py-2 transition-colors"
+            >
+              <Heart
+                size={28}
+                className={
+                  data.liked === true
+                    ? 'fill-orange-5 text-orange-5'
+                    : 'text-gray-5'
+                }
+              />
+              <span className="text-gray-5">{data.likeCount}</span>
+            </button>
+          </div>
+        )}
+      </article>
+
+      {/* 로그인 이동 안내 Dialog */}
+      <ConfirmDialog
+        variant="confirm-cancel"
+        open={isLoginModalOpen}
+        dispatch={(action) => {
+          if (action.type === 'CLOSE') setIsLoginModalOpen(false);
+        }}
+        emphasis="title-strong"
+        onConfirm={() => {
+          const from = encodeURIComponent(window.location.pathname);
+          router.replace(`${PUBLIC.CORE.LOGIN}?from=${from}`);
+        }}
+        onCancel={() => setIsLoginModalOpen(false)}
+        title="로그인이 필요해요"
+        description="마음에 든 칼럼에 좋아요를 눌러보세요."
+        confirmText="로그인하기"
+        cancelText="취소"
+      />
+    </>
   );
 }

--- a/src/features/community/column/components/column-detail-view.tsx
+++ b/src/features/community/column/components/column-detail-view.tsx
@@ -65,6 +65,7 @@ export default function ColumnDetailView({
         <span>{data.authorName ?? data.authorNickname ?? '알 수 없음'}</span>
         <span>{getRelativeTimeString(data.regDate)}</span>
         <span>조회 {data.viewCount}</span>
+        <span>좋아요 {data.likeCount}</span>
       </div>
       <div className="mb-6 flex flex-wrap gap-2">
         {data.tags.map((tag) => (

--- a/src/features/community/column/components/column-detail-view.tsx
+++ b/src/features/community/column/components/column-detail-view.tsx
@@ -4,9 +4,12 @@ import { ColumnDetail } from '@/entities/column';
 import {
   useColumnDetail,
   useMyColumnDetail,
+  useToggleColumnLike,
 } from '@/features/community/column/hooks/use-column-detail';
 import { TextViewer, parseEditorContent } from '@/shared/components/editor';
 import { getRelativeTimeString } from '@/shared/lib';
+import { classifyColumnError, handleApiError } from '@/shared/lib/errors';
+import { Heart } from 'lucide-react';
 
 export default function ColumnDetailView({
   id,
@@ -28,6 +31,8 @@ export default function ColumnDetailView({
     isError: privateError,
   } = useMyColumnDetail(id, { enabled: isPrivate });
 
+  const toggleColumnLikeMutation = useToggleColumnLike(id);
+
   const data = isPrivate ? privateData : publicData;
   const isLoading = isPrivate ? privateLoading : publicLoading;
   const isError = isPrivate ? privateError : publicError;
@@ -37,6 +42,16 @@ export default function ColumnDetailView({
   if (!data) return null;
 
   const content = parseEditorContent(data.resolvedContent.content);
+
+  const handleLikeToggle = () => {
+    toggleColumnLikeMutation.mutate(undefined, {
+      onError: (error) => {
+        handleApiError(error, classifyColumnError, {
+          onContext: () => {},
+        });
+      },
+    });
+  };
 
   return (
     <article>
@@ -62,6 +77,27 @@ export default function ColumnDetailView({
         ))}
       </div>
       <TextViewer value={content} />
+
+      {/* 좋아요 버튼 */}
+      {!isPrivate && (
+        <div className="mt-10 flex justify-center">
+          <button
+            onClick={handleLikeToggle}
+            disabled={toggleColumnLikeMutation.isPending}
+            className="border-line-line1 hover:bg-background-orange flex cursor-pointer items-center gap-1.5 rounded-full border px-8 py-2 transition-colors"
+          >
+            <Heart
+              size={28}
+              className={
+                data.liked === true
+                  ? 'fill-orange-5 text-orange-5'
+                  : 'text-gray-5'
+              }
+            />
+            <span className="text-gray-5">{data.likeCount}</span>
+          </button>
+        </div>
+      )}
     </article>
   );
 }

--- a/src/features/community/column/hooks/use-column-detail.ts
+++ b/src/features/community/column/hooks/use-column-detail.ts
@@ -11,7 +11,7 @@ export const useColumnDetail = (
 ) =>
   useQuery({
     queryKey: columnKeys.detail(id),
-    queryFn: () => repository.getColumnDetail(id),
+    queryFn: () => repository.getColumnDetailWithAuth(id),
     initialData,
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,

--- a/src/features/community/column/hooks/use-column-detail.ts
+++ b/src/features/community/column/hooks/use-column-detail.ts
@@ -1,5 +1,5 @@
 import { ColumnDetail, columnKeys, repository } from '@/entities/column';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 /**
  * [GET] 칼럼 상세 조회
@@ -32,3 +32,14 @@ export const useMyColumnDetail = (
     gcTime: 30 * 60 * 1000,
     enabled: options?.enabled ?? true,
   });
+
+export const useToggleColumnLike = (id: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => repository.toggleColumnLike(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: columnKeys.all });
+    },
+  });
+};

--- a/src/features/mypage/column/components/my-column-item.tsx
+++ b/src/features/mypage/column/components/my-column-item.tsx
@@ -49,7 +49,7 @@ export default function MyColumnItem({ column }: { column: MyColumnListItem }) {
             ? `${PUBLIC.COMMUNITY.COLUMN.DETAIL(column.id)}?preview=true`
             : PUBLIC.COMMUNITY.COLUMN.DETAIL(column.id)
         }
-        subtitle={`조회수 ${column.viewCount} | 작성일 ${getRelativeTimeString(column.regDate)}`}
+        subtitle={`조회수 ${column.viewCount} | 작성일 ${getRelativeTimeString(column.regDate)} | 좋아요 ${column.likeCount}`}
         rightTitle={
           <StatusBadge
             label={COLUMN_STATUS_LABEL[column.status]}

--- a/src/shared/lib/errors/errors.ts
+++ b/src/shared/lib/errors/errors.ts
@@ -112,6 +112,7 @@ export function classifyColumnError(code?: string): ApiErrorType {
     case 'COLUMN_ARTICLE_NOT_EXIST':
     case 'COLUMN_ARTICLE_ALREADY_APPROVED':
     case 'COLUMN_ARTICLE_NOT_OWNED':
+    case 'COLUMN_ARTICLE_LIKE_FORBIDDEN':
       return 'CONTEXT';
 
     // AUTH (권한 문제)


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
<!-- 
- 변경된 내용에 대해 간략하게 설명해주세요.
- 예: 사용자 로그인 기능 추가
- 예: API 응답 구조 변경 
-->
- 칼럼 상세에 좋아요 토글 버튼 추가
- 클라이언트 fetch를 api.private(BFF 경유)로 전환해 liked 상태 정상 반영
- 공개/내 칼럼/관리자 목록 및 상세에 좋아요 수 표시 추가
- 관리자 상세 검토 배너 개선 및 승인된 글 공개 게시글 바로가기 추가
  
## 🧐 관련 이슈
<!--
- 관련된 이슈 번호를 적어주세요. (ex. `Closes #123`, `Fixes #456`) 
-->
BTS-696

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->
<img width="846" height="249" alt="image" src="https://github.com/user-attachments/assets/9cab7c63-79bc-4370-a077-dffe2a27ba17" />


## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
