### PR TITLE
FE-7 AI 코드 생성 하네스 추가

### DIFF
--- a/.ai/hooks/ai-check.sh
+++ b/.ai/hooks/ai-check.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+# AI Guardrails Check
+# 사용법: bash .ai/hooks/ai-check.sh
+#
+# 목적: AI agent가 생성한 신규 코드의 레이어 위반을 감지한다.
+# 범위: 신규 코드 기준. 기존 레거시 코드(features/auth, features/study-notes 등)는
+#       AGENTS.md "Do not refactor existing code" 원칙에 따라 검사 제외.
+
+set -e
+ERRORS=0
+
+echo "=== AI Guardrails Check ==="
+echo "대상: 신규 생성 코드 기준 (기존 레거시 경로 제외)"
+echo ""
+
+# ── 레거시 경로 목록 (기존 위반이 이미 존재하는 경로 — 신규 작성 금지) ──────────
+# 이 경로들은 리팩토링 금지 원칙에 따라 현재 검사에서 제외한다.
+# 신규 파일은 이 경로에 추가하지 않는다.
+LEGACY_FEATURE_PATHS=(
+  "src/features/auth"
+  "src/features/study-notes/api"
+  "src/features/dashboard/studynote"
+  "src/features/dashboard/api"
+  "src/features/list/api"
+  "src/features/qna/services"
+  "src/features/qna/components"
+  "src/features/invite"
+  "src/features/study-rooms/api"
+  "src/features/study-rooms/components/sidebar/services"
+  "src/features/study-rooms/model"
+)
+
+# ── 1. 신규 features 코드에서 API 클라이언트 직접 사용 검사 ─────────────────────
+echo "1. features 레이어 API 직접 사용 검사 (레거시 경로 제외)..."
+
+FOUND=""
+while IFS= read -r f; do
+  IS_LEGACY=false
+  for legacy in "${LEGACY_FEATURE_PATHS[@]}"; do
+    if [[ "$f" == $legacy* ]]; then
+      IS_LEGACY=true
+      break
+    fi
+  done
+  [ "$IS_LEGACY" = true ] && continue
+  [[ "$f" == *"__tests__"* ]] && continue
+
+  MATCH=$(grep -n "api\.private\|api\.public" "$f" 2>/dev/null || true)
+  if [ -n "$MATCH" ]; then
+    FOUND="$FOUND\n$f:\n$MATCH"
+  fi
+done < <(find src/features \( -name "*.ts" -o -name "*.tsx" \) 2>/dev/null)
+
+if [ -n "$FOUND" ]; then
+  echo "❌ [LAYER VIOLATION] features에서 API 클라이언트 직접 사용 감지:"
+  echo -e "$FOUND"
+  echo "   → API 호출을 entities/{domain}/infrastructure/{domain}.repository.ts 로 이동하세요"
+  echo "   → 참조: docs/architecture.md Rule 1"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "   ✅ 통과"
+fi
+
+echo ""
+
+# ── 2. 폐기된 BFF 클라이언트 사용 검사 ────────────────────────────────────────
+# 제외: src/app/api/ (Next.js BFF 라우트 — api.bff.server 사용이 정상)
+# 제외: 레거시 features/auth, features/dashboard, entities/member (기존 코드)
+echo "2. 폐기된 api.bff 클라이언트 사용 검사 (BFF 라우트·레거시 제외)..."
+
+BFF_LEGACY=(
+  "src/app/api"
+  "src/features/auth"
+  "src/features/dashboard/api"
+  "src/entities/member"
+)
+
+BFF_FOUND=""
+while IFS= read -r f; do
+  IS_EXCLUDED=false
+  for ex in "${BFF_LEGACY[@]}"; do
+    if [[ "$f" == $ex* ]]; then
+      IS_EXCLUDED=true
+      break
+    fi
+  done
+  [ "$IS_EXCLUDED" = true ] && continue
+
+  MATCH=$(grep -n "api\.bff\.client\|api\.bff\.server" "$f" 2>/dev/null || true)
+  if [ -n "$MATCH" ]; then
+    BFF_FOUND="$BFF_FOUND\n$f:\n$MATCH"
+  fi
+done < <(find src \( -name "*.ts" -o -name "*.tsx" \) 2>/dev/null)
+
+if [ -n "$BFF_FOUND" ]; then
+  echo "❌ [DEPRECATED] api.bff.client / api.bff.server 사용 감지:"
+  echo -e "$BFF_FOUND"
+  echo "   → api.private (인증 필요) 또는 api.public (인증 불필요) 을 사용하세요"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "   ✅ 통과"
+fi
+
+echo ""
+
+# ── 3. queryKey 배열 리터럴 하드코딩 검사 ─────────────────────────────────────
+echo "3. queryKey 하드코딩 검사 (레거시 경로 제외)..."
+
+QUERYKEY_LEGACY=(
+  "src/features/qna"
+  "src/features/invite"
+)
+
+QUERYKEY_FOUND=""
+while IFS= read -r f; do
+  # .keys.ts 파일 자체 제외
+  [[ "$f" == *.keys.ts ]] && continue
+  [[ "$f" == *"__tests__"* ]] && continue
+
+  IS_LEGACY=false
+  for legacy in "${QUERYKEY_LEGACY[@]}"; do
+    if [[ "$f" == $legacy* ]]; then
+      IS_LEGACY=true
+      break
+    fi
+  done
+  [ "$IS_LEGACY" = true ] && continue
+
+  MATCH=$(grep -n "queryKey: \['" "$f" 2>/dev/null | grep -v "Keys\.\|keys\." || true)
+  if [ -n "$MATCH" ]; then
+    QUERYKEY_FOUND="$QUERYKEY_FOUND\n$f:\n$MATCH"
+  fi
+done < <(find src -name "*.ts" -o -name "*.tsx" 2>/dev/null)
+
+if [ -n "$QUERYKEY_FOUND" ]; then
+  echo "❌ [RULE VIOLATION] queryKey 배열 리터럴 하드코딩 감지:"
+  echo -e "$QUERYKEY_FOUND"
+  echo "   → {domain}Keys.list() 등 키 팩토리를 사용하세요"
+  echo "   → 참조: docs/entities.md — TanStack Query Keys"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "   ✅ 통과"
+fi
+
+echo ""
+
+# ── 4. types/index.ts에서 DTO 스키마 직접 re-export 검사 ──────────────────────
+# 검사 대상: z.infer<> 없이 infrastructure 파일에서 스키마를 그대로 re-export하는 경우
+# 허용: export type Xxx = z.infer<typeof dto.xxx>  (이름에 DTO 포함해도 무관)
+# 금지: export { XxxDtoSchema } from '../infrastructure/...'
+#        export type { XxxDtoSchema } from '../infrastructure/...'
+echo "4. types/index.ts DTO 스키마 직접 re-export 검사..."
+FOUND=$(grep -rn "from.*infrastructure\|from.*\.dto" \
+  src/entities/*/types/index.ts 2>/dev/null | \
+  grep "^.*export" || true)
+
+if [ -n "$FOUND" ]; then
+  echo "❌ [LAYER VIOLATION] types/index.ts에서 infrastructure 스키마 직접 re-export 감지:"
+  echo "$FOUND"
+  echo "   → z.infer<typeof dto.xxx> 형태로 변환된 타입만 export하세요"
+  echo "   → 타입 이름에 DTO suffix를 사용하는 것은 허용됩니다"
+  echo "   → 참조: docs/entities.md Rule 1"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "   ✅ 통과"
+fi
+
+echo ""
+
+# ── 5. 신규 domain.ts 의존 방향 검사 (INFO 레벨) ──────────────────────────────
+# 기존 코드는 이 패턴을 사용하므로 ERROR가 아닌 INFO로만 출력한다.
+# 신규 도메인 작성 시 domain.ts에서 infrastructure를 import하지 않는 것을 권장한다.
+echo "5. domain.ts 의존 방향 검사 (신규 도메인만, INFO)..."
+
+NEW_DOMAINS=()  # 신규 도메인이 있으면 여기에 추가
+DOMAIN_VIOLATIONS=""
+
+if [ ${#NEW_DOMAINS[@]} -gt 0 ]; then
+  for domain in "${NEW_DOMAINS[@]}"; do
+    MATCH=$(grep -rn "from.*infrastructure\|from.*\.dto\|from.*\.repository" \
+      "src/entities/$domain/core/" --include="*.ts" 2>/dev/null || true)
+    if [ -n "$MATCH" ]; then
+      DOMAIN_VIOLATIONS="$DOMAIN_VIOLATIONS\n$MATCH"
+    fi
+  done
+fi
+
+if [ -n "$DOMAIN_VIOLATIONS" ]; then
+  echo "   ℹ️  [INFO] 신규 domain.ts에서 infrastructure import 감지:"
+  echo -e "$DOMAIN_VIOLATIONS"
+  echo "   → domain.ts는 순수 Zod 스키마만 정의하는 것을 권장합니다"
+  echo "   → 변환 로직은 repository.ts에 작성하세요"
+  echo "   → (기존 도메인의 동일 패턴은 레거시로 허용됩니다)"
+else
+  echo "   ✅ 통과 (신규 도메인 없음)"
+fi
+
+echo ""
+
+# ── 6. TypeScript 타입 검사 ──────────────────────────────────────────────────
+echo "6. TypeScript 타입 검사..."
+if yarn tsc --noEmit 2>&1; then
+  echo "   ✅ 통과"
+else
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
+
+# ── 7. ESLint 검사 ─────────────────────────────────────────────────────────
+echo "7. ESLint 검사..."
+if yarn lint 2>&1; then
+  echo "   ✅ 통과"
+else
+  ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
+
+# ── 결과 출력 ─────────────────────────────────────────────────────────────────
+echo "─────────────────────────────────────"
+if [ $ERRORS -eq 0 ]; then
+  echo "✅ 모든 guardrail 검사 통과"
+else
+  echo "❌ 총 ${ERRORS}개 위반 감지"
+  echo "   위 항목을 수정한 후 다시 실행하세요."
+  echo "   참조: .ai/hooks/guardrails.yaml"
+  exit 1
+fi

--- a/.ai/hooks/guardrails.yaml
+++ b/.ai/hooks/guardrails.yaml
@@ -1,0 +1,229 @@
+# guardrails.yaml
+# AI agent가 코드를 생성하거나 수정할 때 위반을 감지하는 규칙 목록.
+# 각 rule은 pre_write(생성 전) 또는 post_write(생성 후) 이벤트에 적용된다.
+
+name: layer-violation-guardrails
+version: 1.0.0
+description: |
+  FSD 아키텍처 레이어 위반 및 프로젝트 코딩 규칙 위반을 감지한다.
+  위반 감지 시 해당 파일 생성/수정을 차단하고 해결 안내를 출력한다.
+
+# ── 레이어 위반 ────────────────────────────────────────────────────────────────
+
+rules:
+  - id: no_api_in_features
+    name: features에서 API 클라이언트 직접 사용 금지
+    event: pre_write
+    path_pattern:
+      - 'src/features/**/*.ts'
+      - 'src/features/**/*.tsx'
+    check:
+      forbidden_imports:
+        - "from '@/shared/api'"
+        - 'api.private'
+        - 'api.public'
+      forbidden_patterns:
+        - "api\\.private\\."
+        - "api\\.public\\."
+    severity: error
+    message: |
+      [LAYER VIOLATION] features에서 API 클라이언트를 직접 사용할 수 없습니다.
+
+      해결:
+        1. API 호출을 entities/{domain}/infrastructure/{domain}.repository.ts 로 이동
+        2. features에서는 repository 함수를 import해서 사용
+
+      참조: docs/architecture.md Rule 1
+
+  - id: no_deprecated_api_client
+    name: 폐기된 BFF 클라이언트 사용 금지
+    event: pre_write
+    path_pattern:
+      - 'src/**/*.ts'
+      - 'src/**/*.tsx'
+    check:
+      forbidden_patterns:
+        - "api\\.bff\\.client"
+        - "api\\.bff\\.server"
+    severity: error
+    message: |
+      [DEPRECATED] api.bff.client / api.bff.server는 폐기된 클라이언트입니다.
+
+      해결: api.private (인증 필요) 또는 api.public (인증 불필요) 를 사용하세요.
+
+      참조: docs/architecture.md — API Clients
+
+  - id: no_dto_type_in_types_index
+    name: types/index.ts에서 DTO 타입 직접 export 금지
+    event: pre_write
+    path_pattern:
+      - 'src/entities/*/types/index.ts'
+    check:
+      forbidden_patterns:
+        - 'export.*DTO'
+        - 'export.*DtoSchema'
+        - "export.*Dto\\b"
+    severity: error
+    message: |
+      [LAYER VIOLATION] types/index.ts에서 DTO 타입을 직접 export하면 안 됩니다.
+
+      해결: z.infer<typeof dto.xxx> 형태로 변환된 타입만 export하세요.
+
+      예시:
+        // ❌ 금지
+        export type { InquiryDetailDtoSchema } from '../infrastructure/inquiry.dto';
+
+        // ✅ 허용
+        export type Inquiry = z.infer<typeof dto.detail>;
+
+      참조: docs/entities.md Rule 1
+
+  - id: no_infrastructure_import_in_domain
+    name: domain.ts에서 infrastructure import 금지
+    event: pre_write
+    path_pattern:
+      - 'src/entities/*/core/*.domain.ts'
+      - 'src/entities/*/core/*.domain.schema.ts'
+    check:
+      forbidden_patterns:
+        - 'from.*infrastructure'
+        - "from.*\\.dto"
+        - "from.*\\.repository"
+    severity: error
+    message: |
+      [LAYER VIOLATION] domain.ts는 infrastructure를 import할 수 없습니다.
+
+      의존 방향: infrastructure → core (역방향 금지)
+
+      해결: domain.ts는 순수 Zod 스키마만 정의하세요.
+      변환 로직은 infrastructure/repository.ts 에 작성하세요.
+
+      참조: docs/entities.md Rule 2
+
+  - id: query_key_no_hardcoded_array
+    name: queryKey 배열 리터럴 하드코딩 금지
+    event: pre_write
+    path_pattern:
+      - 'src/features/**/*.ts'
+      - 'src/features/**/*.tsx'
+      - 'src/entities/**/*.ts'
+    check:
+      forbidden_patterns:
+        # useQuery/useInfiniteQuery에서 배열 리터럴 직접 사용
+        - "queryKey:\\s*\\['[a-z]"
+        - "queryKey:\\s*\\[\"[a-z]"
+    severity: error
+    message: |
+      [RULE VIOLATION] queryKey를 배열 리터럴로 직접 작성할 수 없습니다.
+
+      해결: entities/{domain}/infrastructure/{domain}.keys.ts 의 키 팩토리를 사용하세요.
+
+      예시:
+        // ❌ 금지
+        useQuery({ queryKey: ['inquiry', 'list'] })
+
+        // ✅ 허용
+        useQuery({ queryKey: inquiryKeys.list({ page, size }) })
+
+      참조: docs/entities.md — TanStack Query Keys
+
+  - id: mutation_requires_invalidate_queries
+    name: mutation hook에 invalidateQueries 누락 감지
+    event: post_write
+    path_pattern:
+      - 'src/features/**/use-create-*.ts'
+      - 'src/features/**/use-update-*.ts'
+      - 'src/features/**/use-delete-*.ts'
+    check:
+      required_patterns:
+        - 'invalidateQueries'
+    severity: warning
+    message: |
+      [MISSING] mutation hook에 invalidateQueries가 없습니다.
+
+      onSuccess에서 관련 쿼리를 무효화하지 않으면 캐시가 stale 상태로 남습니다.
+
+      예시:
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: {domain}Keys.all });
+        },
+
+      참조: .ai/skills/create-post-mutation.md
+
+  - id: mutation_requires_handle_api_error
+    name: mutation hook 또는 호출부에 handleApiError 누락 감지
+    event: post_write
+    path_pattern:
+      - 'src/features/**/use-create-*.ts'
+      - 'src/features/**/use-update-*.ts'
+      - 'src/features/**/use-delete-*.ts'
+    check:
+      required_patterns:
+        - 'handleApiError'
+    severity: warning
+    message: |
+      [CHECK] mutation hook에 handleApiError가 없습니다.
+
+      폼 없는 액션(토글, 삭제 등): 훅 내부 onError에 handleApiError를 작성하세요.
+      폼 있는 mutation(작성/수정): setError 접근을 위해 컴포넌트의 mutate(data, { onError }) 에 작성하세요.
+        → 이 경우 훅에 handleApiError가 없는 것이 정상입니다.
+
+      참조: .ai/skills/create-post-mutation.md — onError 처리 위치 선택
+            .ai/skills/handle-api-error.md
+
+  - id: payload_parse_before_api_call
+    name: repository에서 payload 검증 누락 감지
+    event: post_write
+    path_pattern:
+      - 'src/entities/*/infrastructure/*.repository.ts'
+    check:
+      # POST / PUT / PATCH 함수 내에 .parse( 호출이 있어야 함
+      context_required:
+        method_pattern: "api\\.private\\.(post|put|patch)"
+        near_pattern: "\\.parse\\("
+        within_lines: 5
+    severity: warning
+    message: |
+      [MISSING] repository 함수에서 API 호출 전 payload 검증이 누락되었습니다.
+
+      예시:
+        const create{Domain} = async (params: {Domain}Payload) => {
+          const validated = payload.create.parse(params);  // ← 필수
+          const response = await api.private.post('/...', validated);
+          return unwrapEnvelope(response, dto.item);
+        };
+
+# ── 수정 제한 경로 ──────────────────────────────────────────────────────────────
+
+restricted_paths:
+  - path: 'src/shared/api/http/'
+    reason: 'HTTP 클라이언트 설정 — 임의 수정 금지'
+    on_attempt:
+      severity: error
+      message: |
+        [RESTRICTED] src/shared/api/http/ 는 직접 수정할 수 없습니다.
+        HTTP 클라이언트 동작 변경이 필요하면 팀에 먼저 공유하세요.
+
+  - path: 'src/shared/lib/api-utils.ts'
+    reason: 'unwrapEnvelope 구현 — 임의 수정 금지'
+    on_attempt:
+      severity: error
+      message: |
+        [RESTRICTED] api-utils.ts는 직접 수정할 수 없습니다.
+        unwrapEnvelope 동작 변경이 필요하면 팀에 먼저 공유하세요.
+
+  - path: 'src/shared/components/'
+    reason: '공유 컴포넌트 — 변경이 다른 feature에 영향을 줄 수 있음'
+    on_attempt:
+      severity: warning
+      message: |
+        [CAUTION] shared/components 수정은 다른 feature에 영향을 줄 수 있습니다.
+        수정 범위와 영향을 먼저 확인하세요.
+
+# ── 자동 실행 스크립트 ──────────────────────────────────────────────────────────
+# 아래 규칙들은 ai-check.sh 스크립트로 CI / pre-commit에서 실행 가능하다.
+# 사용법: bash .ai/hooks/ai-check.sh
+
+scripts:
+  ai_check:
+    path: '.ai/hooks/ai-check.sh'

--- a/.ai/skills/create-crud-flow.md
+++ b/.ai/skills/create-crud-flow.md
@@ -1,0 +1,315 @@
+# Skill: create-crud-flow
+
+## 역할
+
+단일 도메인에 대한 CRUD 전체(DTO, payload, keys, repository, types)를 순서대로 생성한다.
+mutation hook은 별도 skill(`create-post-mutation.md`)을 참조한다.
+
+---
+
+## Trigger 조건
+
+- "~~ CRUD 만들어줘 / 추가해줘 / 생성해줘"
+- "~~ entities 만들어줘"
+- endpoint + request body + response schema를 함께 제시하는 경우
+- 새 도메인의 repository가 아직 없는 경우
+
+---
+
+## Required Input
+
+AI agent에게 아래 정보를 제공해야 한다.
+
+```
+domain: quiz                         # 단수 소문자 (파일명/변수명 기준)
+domainPascal: Quiz                   # PascalCase (타입/변수명)
+endpoints:
+  list:   GET    /teacher/quizzes
+  detail: GET    /teacher/quizzes/{id}
+  create: POST   /teacher/quizzes
+  update: PUT    /teacher/quizzes/{id}
+  delete: DELETE /teacher/quizzes/{id}
+request_body:
+  studyRoomId: number
+  title: string
+  content: string
+response_item:
+  id: number
+  title: string
+  content: string
+  createdAt: string        # ISO 8601 날짜 문자열
+list_paginated: true       # false면 배열 단순 반환
+error_codes:               # 선택값. 없으면 default: UNKNOWN만 작성
+  FIELD:                   # 사용자가 입력 수정으로 해결 가능
+    - QUIZ_DUPLICATE_TITLE
+  CONTEXT:                 # 리소스 소멸 / 페이지 무효
+    - QUIZ_NOT_FOUND
+  AUTH:                    # 권한 없음 / 재로그인
+    - QUIZ_FORBIDDEN
+```
+
+---
+
+## Steps
+
+### Step 1 — 디렉토리 구조 확인
+
+```
+entities/{domain}/
+  infrastructure/
+    {domain}.dto.ts          ← 응답 DTO + 요청 payload 스키마
+    {domain}.repository.ts   ← API 호출 + 응답 파싱
+    {domain}.keys.ts         ← TanStack Query 키 팩토리
+  types/
+    index.ts                 ← UI 소비용 타입만 export
+  index.ts                   ← 외부 공개 barrel
+```
+
+아직 없으면 위 구조로 디렉토리를 생성한다.
+
+---
+
+### Step 2 — DTO 스키마 생성
+
+파일: `entities/{domain}/infrastructure/{domain}.dto.ts`
+
+**규칙**
+
+- 응답 스키마는 `dto` 객체로 묶어 export
+- 요청 스키마(payload)는 `payload` 객체로 묶어 별도 export
+- 날짜는 `z.string()` (ISO 문자열, 변환 없이 사용)
+- nullable 필드는 `.nullable()` 또는 `.nullish()`
+- enum은 `z.enum([...])` 별도 선언 후 재사용
+
+```ts
+import { z } from 'zod';
+
+// ── 응답 DTO ──────────────────────────────────────────
+const {Domain}ItemDtoSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  content: z.string(),
+  createdAt: z.string(),
+});
+
+// 페이지네이션 응답인 경우
+const {Domain}ListDtoSchema = z.object({
+  totalPages: z.number(),
+  totalElements: z.number(),
+  content: z.array({Domain}ItemDtoSchema),
+});
+
+// ── 요청 payload ─────────────────────────────────────
+const {Domain}PayloadSchema = z.object({
+  studyRoomId: z.number(),
+  title: z.string().min(1, '제목은 필수입니다.'),
+  content: z.string(),
+});
+
+// 부분 업데이트(PATCH)용 — PUT에는 불필요
+const {Domain}PatchPayloadSchema = {Domain}PayloadSchema.partial();
+
+// ── export ────────────────────────────────────────────
+export const dto = {
+  item: {Domain}ItemDtoSchema,
+  list: {Domain}ListDtoSchema,         // 페이지네이션 없으면 생략
+};
+
+export const payload = {
+  create: {Domain}PayloadSchema,
+  update: {Domain}PayloadSchema,       // PUT: 전체 필드 동일
+  patch:  {Domain}PatchPayloadSchema,  // PATCH: 부분 필드 (필요 시만)
+};
+```
+
+---
+
+### Step 3 — Query Key 팩토리 생성
+
+파일: `entities/{domain}/infrastructure/{domain}.keys.ts`
+
+**규칙**
+
+- `all` 배열이 최상위 prefix — 전체 invalidate 시 사용
+- 파라미터가 없는 키는 `() =>` 함수 형태 유지 (일관성)
+- 접두어 키(Prefix)는 `invalidateQueries` 범위 제한에 사용
+
+```ts
+export const {domain}Keys = {
+  all: ['{domain}'] as const,
+
+  list: (params: { page: number; size: number }) =>
+    [...{domain}Keys.all, 'list', params] as const,
+
+  detail: (id: number) =>
+    [...{domain}Keys.all, 'detail', id] as const,
+};
+```
+
+페이지네이션 없는 단순 목록이면:
+
+```ts
+list: () => [...{domain}Keys.all, 'list'] as const,
+```
+
+---
+
+### Step 4 — Repository 생성
+
+파일: `entities/{domain}/infrastructure/{domain}.repository.ts`
+
+**규칙**
+
+- `api.private` 또는 `api.public` 만 사용 (`api.bff.*` 금지)
+- 응답 파싱: `unwrapEnvelope(response, dto.xxx)` 사용
+- 요청 전 payload 검증: `payload.xxx.parse(params)` 호출
+- 반환 타입은 명시하지 않아도 되지만, 복잡하면 명시
+- 마지막에 `export const repository = { ... }` 로 묶어 export
+
+```ts
+import { api } from '@/shared/api';
+import { unwrapEnvelope } from '@/shared/lib/api-utils';
+
+import { dto, payload } from './{domain}.dto';
+
+// ── [LIST] GET /teacher/{domain}s ─────────────────────
+const get{Domain}List = async (params: { page: number; size: number }) => {
+  const response = await api.private.get('/{role}/{domain}s', { params });
+  return unwrapEnvelope(response, dto.list);
+};
+
+// ── [DETAIL] GET /teacher/{domain}s/{id} ─────────────
+const get{Domain} = async (id: number) => {
+  const response = await api.private.get(`/{role}/{domain}s/${id}`);
+  return unwrapEnvelope(response, dto.item);
+};
+
+// ── [CREATE] POST /teacher/{domain}s ─────────────────
+const create{Domain} = async (params: z.infer<typeof payload.create>) => {
+  const validated = payload.create.parse(params);
+  const response = await api.private.post('/{role}/{domain}s', validated);
+  return unwrapEnvelope(response, dto.item);
+};
+
+// ── [UPDATE] PUT /teacher/{domain}s/{id} ─────────────
+const update{Domain} = async (id: number, params: z.infer<typeof payload.update>) => {
+  const validated = payload.update.parse(params);
+  const response = await api.private.put(`/{role}/{domain}s/${id}`, validated);
+  return unwrapEnvelope(response, dto.item);
+};
+
+// ── [DELETE] DELETE /teacher/{domain}s/{id} ──────────
+const delete{Domain} = async (id: number) => {
+  await api.private.delete(`/{role}/{domain}s/${id}`);
+};
+
+// ── 내보내기 ──────────────────────────────────────────
+export const repository = {
+  getList: get{Domain}List,
+  get: get{Domain},
+  create: create{Domain},
+  update: update{Domain},
+  delete: delete{Domain},
+};
+```
+
+**CREATE가 ID만 반환하는 경우** (SuccessId 패턴):
+
+```ts
+import type { SuccessId } from '@/types';
+// unwrapEnvelope 대신:
+const response = await api.private.post('/...', validated);
+return unwrapEnvelope(response, z.object({ id: z.number() }));
+```
+
+---
+
+### Step 5 — Types 내보내기
+
+파일: `entities/{domain}/types/index.ts`
+
+**규칙**
+
+- DTO 타입을 직접 export하지 않는다 — `z.infer<>` 로 변환한 타입만
+- 컴포넌트는 이 파일의 타입만 소비한다
+
+```ts
+import { z } from 'zod';
+import { dto, payload } from '../infrastructure/{domain}.dto';
+
+export type {Domain} = z.infer<typeof dto.item>;
+export type {Domain}List = z.infer<typeof dto.list>;
+export type {Domain}Payload = z.infer<typeof payload.create>;
+```
+
+---
+
+### Step 6 — Barrel export
+
+파일: `entities/{domain}/index.ts`
+
+```ts
+export { repository } from './infrastructure/{domain}.repository';
+export { {domain}Keys } from './infrastructure/{domain}.keys';
+export type { {Domain}, {Domain}List, {Domain}Payload } from './types';
+```
+
+---
+
+### Step 7 — classify 에러 함수 추가
+
+파일: `src/shared/lib/errors/errors.ts` 에 추가
+
+```ts
+export function classify{Domain}Error(code?: string): ApiErrorType {
+  switch (code) {
+    // FIELD: 사용자가 입력값을 고쳐서 해결 가능
+    case '{DOMAIN}_INVALID_INPUT':
+      return 'FIELD';
+
+    // CONTEXT: 리소스 소멸 / 페이지가 더 이상 유효하지 않음
+    case '{DOMAIN}_NOT_FOUND':
+    case '{DOMAIN}_ALREADY_EXISTS':
+      return 'CONTEXT';
+
+    // AUTH: 권한 없음 / 재로그인 필요
+    case '{DOMAIN}_FORBIDDEN':
+    case 'MEMBER_NOT_EXIST':
+      return 'AUTH';
+
+    default:
+      return 'UNKNOWN';
+  }
+}
+```
+
+`error_codes`가 제공된 경우 해당 케이스를 채운다.
+제공되지 않은 경우 `default: return 'UNKNOWN'` 만 작성하고 코드가 확정되면 채운다.
+
+---
+
+## Validation Checklist
+
+생성 후 아래 항목을 순서대로 확인한다.
+
+```
+[ ] dto.ts에 dto / payload 객체가 분리 export되어 있음
+[ ] keys.ts의 all 배열이 단일 도메인 문자열 prefix임
+[ ] repository에서 features 디렉토리를 import하지 않음
+[ ] repository 내 모든 함수에서 payload.xxx.parse() 호출 후 API 호출
+[ ] types/index.ts에 DTO 타입 직접 export 없음 (z.infer<> 사용)
+[ ] domain.ts가 infrastructure를 import하지 않음 (변환 필요 시)
+[ ] errors.ts에 classify{Domain}Error 추가됨
+[ ] yarn tsc --noEmit 통과
+[ ] yarn lint 통과
+```
+
+---
+
+## Retrieval Docs
+
+실행 전 아래 파일을 읽는다.
+
+- `docs/entities.md` — 전체 구조 규칙
+- `docs/architecture.md` — API 클라이언트, 레이어 규칙
+- `docs/error-handling.md` — classify 함수 추가 위치

--- a/.ai/skills/create-post-mutation.md
+++ b/.ai/skills/create-post-mutation.md
@@ -1,0 +1,231 @@
+# Skill: create-post-mutation
+
+## 역할
+
+POST / PUT / PATCH / DELETE 변이(mutation) hook을 생성한다.
+모든 mutation hook은 아래 두 가지를 반드시 포함한다.
+
+1. `mutationFn` 내 payload 검증 (`payload.xxx.parse()`)
+2. `onSuccess` 내 `invalidateQueries`
+
+`handleApiError`는 폼 여부에 따라 위치가 달라진다 — 아래 **onError 처리 위치 선택** 참조.
+
+---
+
+## Trigger 조건
+
+- "~~ 생성 hook 만들어줘"
+- "~~ 수정 / 삭제 mutation 추가해줘"
+- repository에 create/update/delete 함수가 이미 있을 때
+- `create-crud-flow` skill 실행 후 Step 7로 진입하는 경우
+
+---
+
+## 파일 위치 규칙
+
+```
+features/{feature}/hooks/use-create-{domain}.ts
+features/{feature}/hooks/use-update-{domain}.ts
+features/{feature}/hooks/use-delete-{domain}.ts
+```
+
+hook은 반드시 `features/` 안에 위치한다. `entities/` 안에 두지 않는다.
+
+---
+
+## onError 처리 위치 선택
+
+| 상황 | 위치 | 이유 |
+| ---- | ---- | ---- |
+| 폼 없는 액션 (토글, 상태 변경, 삭제) | 훅 내부 `useMutation.onError` | `setError` 불필요 |
+| 폼 있는 mutation (작성/수정) | 컴포넌트의 `mutate(data, { onError })` | `setError`가 `useForm` 인스턴스에 묶여 훅에서 접근 불가 |
+
+---
+
+## POST — 리소스 생성
+
+```ts
+// features/{feature}/hooks/use-create-{domain}.ts
+import { {domain}Keys, repository } from '@/entities/{domain}';
+import { classify{Domain}Error } from '@/shared/lib/errors/errors';
+import { handleApiError } from '@/shared/lib/errors/error-handler';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+export const useCreate{Domain} = () => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: repository.create,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: {domain}Keys.all });
+    },
+    onError: (error) => {
+      handleApiError(error, classify{Domain}Error, {
+        onField:   (msg) => { /* setError('root', { message: msg }) — 폼이 있으면 추가 */ },
+        onContext: ()    => router.replace('/{domain}s'),
+        onAuth:    ()    => router.replace('/login'),
+        onUnknown: ()    => {},
+      });
+    },
+  });
+};
+```
+
+**폼과 연결하는 경우** — 훅에서 `onError` 제거, 컴포넌트의 `mutate` 호출 시 처리:
+
+```ts
+// 훅: onError 없이 반환
+export const useCreate{Domain} = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: repository.create,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: {domain}Keys.all });
+    },
+  });
+};
+
+// 컴포넌트: mutate 호출 시 onError 전달
+const { mutate } = useCreate{Domain}();
+const { setError } = useForm<{Domain}Form>();
+
+mutate(data, {
+  onError: (error) => {
+    handleApiError(error, classify{Domain}Error, {
+      onField:   (msg) => setError('root', { message: msg }),
+      onContext: ()    => router.replace('/{domain}s'),
+      onAuth:    ()    => router.replace('/login'),
+    });
+  },
+});
+```
+
+---
+
+## PUT — 전체 교체 (수정)
+
+PUT은 payload 전체 필드가 필수다. `payload.update.parse()` — partial 아님.
+
+```ts
+// features/{feature}/hooks/use-update-{domain}.ts
+import { {domain}Keys, repository } from '@/entities/{domain}';
+import { classify{Domain}Error } from '@/shared/lib/errors/errors';
+import { handleApiError } from '@/shared/lib/errors/error-handler';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+export const useUpdate{Domain} = (id: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: {Domain}Payload) => repository.update(id, params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: {domain}Keys.all });
+    },
+  });
+};
+```
+
+---
+
+## PATCH — 부분 업데이트
+
+PATCH는 변경된 필드만 전송한다. payload 타입은 `Partial<>`.
+
+```ts
+// features/{feature}/hooks/use-update-{domain}-status.ts
+export const useUpdate{Domain}Status = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, ...params }: { id: number } & Partial<{Domain}Payload>) =>
+      repository.patch(id, params),
+    onSuccess: (_, { id }) => {
+      // 상세만 invalidate해도 충분한 경우
+      queryClient.invalidateQueries({ queryKey: {domain}Keys.detail(id) });
+    },
+    onError: (error) => {
+      handleApiError(error, classify{Domain}Error, {
+        onContext: () => { /* 필요 시 처리 */ },
+        onAuth:    () => { /* 필요 시 처리 */ },
+      });
+    },
+  });
+};
+```
+
+**PUT vs PATCH 선택 기준**
+
+| 상황                                     | HTTP  | payload     | Zod 검증                 |
+| ---------------------------------------- | ----- | ----------- | ------------------------ |
+| 수정 폼 전체 제출                        | PUT   | 모든 필드   | `payload.update.parse()` |
+| 상태값 하나만 변경 (공개여부, 상태 토글) | PATCH | 변경 필드만 | `payload.patch.parse()`  |
+
+---
+
+## DELETE — 리소스 삭제
+
+```ts
+// features/{feature}/hooks/use-delete-{domain}.ts
+export const useDelete{Domain} = () => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: (id: number) => repository.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: {domain}Keys.all });
+      router.replace('/{domain}s');
+    },
+    onError: (error) => {
+      handleApiError(error, classify{Domain}Error, {
+        onContext: () => router.replace('/{domain}s'),
+        onAuth:    () => router.replace('/login'),
+      });
+    },
+  });
+};
+```
+
+---
+
+## invalidateQueries 범위 결정 기준
+
+```
+생성(POST)  → keys.all          목록 전체 갱신
+수정(PUT)   → keys.all          목록 + 상세 갱신
+수정(PATCH) → keys.detail(id)   상세만 갱신 (목록 영향 없으면)
+삭제        → keys.all          목록에서 제거
+```
+
+연관 도메인 캐시도 무효화해야 하면 `invalidateQueries`를 추가한다:
+
+```ts
+onSuccess: () => {
+  queryClient.invalidateQueries({ queryKey: {domain}Keys.all });
+  queryClient.invalidateQueries({ queryKey: relatedKeys.all }); // 연관 도메인
+},
+```
+
+---
+
+## Validation Checklist
+
+```
+[ ] mutationFn 내에서 payload.xxx.parse() 또는 repository 함수 내부에서 검증
+[ ] onSuccess에 invalidateQueries 포함
+[ ] handleApiError 처리: 폼 없으면 훅 내부 onError, 폼 있으면 컴포넌트 mutate 호출부
+[ ] classify{Domain}Error가 errors.ts에 존재함
+[ ] hook 파일이 features/ 에 위치함 (entities/ 아님)
+[ ] yarn tsc --noEmit 통과
+```
+
+---
+
+## Retrieval Docs
+
+- `docs/error-handling.md` — classify 함수, handleApiError 패턴
+- `docs/entities.md` — repository / keys import 경로
+- `.ai/skills/handle-api-error.md` — classify 함수 작성법

--- a/.ai/skills/handle-api-error.md
+++ b/.ai/skills/handle-api-error.md
@@ -1,0 +1,158 @@
+# Skill: handle-api-error
+
+## 역할
+
+mutation의 `onError`에 표준 에러 처리를 연결한다.
+새 도메인을 추가할 때 `classifyXxxError` 함수를 `errors.ts`에 등록하고
+mutation hook의 `onError`에서 `handleApiError`로 호출하는 전체 흐름을 완성한다.
+
+---
+
+## Trigger 조건
+
+- 새 도메인 mutation hook을 작성할 때
+- "에러 처리 추가해줘"
+- `onError`가 비어있거나 `console.error`만 있는 경우
+- `create-crud-flow` / `create-post-mutation` skill 실행 중 에러 처리 단계
+
+---
+
+## 에러 처리 레이어 요약
+
+| 레이어                    | 처리 주체                 | 대상                    |
+| ------------------------- | ------------------------- | ----------------------- |
+| 인터셉터 (자동)           | `api.private` 인터셉터    | 네트워크 오류, 5xx, 401 |
+| mutation `onError` (수동) | 개발자 → `handleApiError` | 4xx 비즈니스 에러       |
+
+> 5xx / 401 / 네트워크 오류는 인터셉터가 토스트 + 리다이렉트를 자동 처리한다.
+> `onError`에서 이 케이스를 다시 처리하지 않는다.
+
+---
+
+## Step 1 — classifyXxxError 함수 추가
+
+파일: `src/shared/lib/errors/errors.ts`
+
+기존 classify 함수 목록 아래에 추가한다. 절대 별도 파일 생성 금지.
+
+```ts
+// {domain} 관련 에러
+export function classify{Domain}Error(code?: string): ApiErrorType {
+  switch (code) {
+    // FIELD: 사용자가 입력값을 고쳐서 해결 가능
+    case '{DOMAIN}_DUPLICATE_TITLE':
+    case '{DOMAIN}_INVALID_INPUT':
+      return 'FIELD';
+
+    // CONTEXT: 리소스 소멸 / 페이지가 더 이상 유효하지 않음
+    case '{DOMAIN}_NOT_FOUND':
+    case '{DOMAIN}_ALREADY_DELETED':
+    case 'STUDY_ROOM_NOT_EXIST':
+      return 'CONTEXT';
+
+    // AUTH: 권한 없음 / 재로그인 필요
+    case '{DOMAIN}_FORBIDDEN':
+    case 'MEMBER_NOT_EXIST':
+      return 'AUTH';
+
+    default:
+      return 'UNKNOWN';
+  }
+}
+```
+
+**에러 코드 분류 결정 트리**
+
+```
+"사용자가 입력을 바꿔서 해결할 수 있는가?" → YES → FIELD
+"리소스가 삭제되었거나 페이지가 무효한가?" → YES → CONTEXT
+"권한이 없거나 다시 로그인해야 하는가?"   → YES → AUTH
+그 외 모든 경우                           → UNKNOWN
+```
+
+백엔드 에러 코드가 아직 확정되지 않았으면 `default: return 'UNKNOWN'` 만 작성하고 이후에 채운다.
+
+---
+
+## Step 2 — handleApiError 호출
+
+파일: `features/{feature}/hooks/use-create-{domain}.ts` (또는 다른 mutation hook)
+
+```ts
+import { classify{Domain}Error } from '@/shared/lib/errors/errors';
+import { handleApiError } from '@/shared/lib/errors/error-handler';
+
+// mutation onError:
+onError: (error) => {
+  handleApiError(error, classify{Domain}Error, {
+    onField:   (msg) => setError('root', { message: msg }),
+    onContext: ()    => router.replace('/{domain}s'),
+    onAuth:    ()    => router.replace('/login'),
+    onUnknown: ()    => {},
+  });
+},
+```
+
+**각 handler의 기본 동작**
+
+| 타입        | 기본 동작                       | 언제 사용                            |
+| ----------- | ------------------------------- | ------------------------------------ |
+| `onField`   | `setError('root', { message })` | 폼이 있고 사용자가 수정할 수 있을 때 |
+| `onContext` | `router.replace('/목록')`       | 리소스가 없거나 페이지 무효          |
+| `onAuth`    | `router.replace('/login')`      | 권한 없음                            |
+| `onUnknown` | 빈 함수 `() => {}`              | Sentry가 자동 캡처함                 |
+
+> `handleApiError` 내부에서 에러 토스트를 자동 출력한다.
+> `onError`에서 별도로 `toast.error()`를 호출하지 않는다.
+
+---
+
+## 폼 없는 mutation의 onField 처리
+
+폼이 없는 단순 버튼 액션(좋아요, 상태 변경 등)은 `onField`를 생략하거나 빈 함수:
+
+```ts
+handleApiError(error, classify{Domain}Error, {
+  onContext: () => router.replace('/{domain}s'),
+  onAuth:    () => router.replace('/login'),
+});
+```
+
+---
+
+## Step 3 — errors.ts import 확인
+
+`errors.ts`에서 export한 함수를 mutation hook에서 import할 때 경로:
+
+```ts
+import { classify{Domain}Error } from '@/shared/lib/errors/errors';
+import { handleApiError } from '@/shared/lib/errors/error-handler';
+```
+
+---
+
+## Validation Checklist
+
+```
+[ ] classify{Domain}Error가 errors.ts에 추가됨 (별도 파일 생성 금지)
+[ ] switch-case에 FIELD / CONTEXT / AUTH / UNKNOWN 분류 포함
+[ ] handleApiError가 onError 내에서 호출됨
+[ ] onError에서 5xx / 401 / 네트워크 에러를 수동으로 처리하지 않음
+[ ] toast.error() 등 중복 토스트 호출 없음
+[ ] yarn tsc --noEmit 통과
+```
+
+---
+
+## 실제 프로젝트 예시 참조
+
+`src/shared/lib/errors/errors.ts` — 기존 classify 함수 패턴 확인
+`src/shared/lib/errors/error-handler.ts` — handleApiError 시그니처 확인
+
+---
+
+## Retrieval Docs
+
+- `docs/error-handling.md` — 에러 레이어 원칙, 전체 흐름
+- `src/shared/lib/errors/errors.ts` — 기존 classify 함수 예시
+- `src/shared/lib/errors/error-handler.ts` — handleApiError 구현

--- a/.ai/workflows/crud_requested.yaml
+++ b/.ai/workflows/crud_requested.yaml
@@ -1,0 +1,161 @@
+# workflow: crud_requested
+# 새 도메인의 CRUD entities + mutation hooks 생성을 요청받았을 때 실행한다.
+
+name: crud_requested
+description: |
+  도메인 CRUD 생성 요청 시 실행되는 표준 워크플로우.
+  DTO → Keys → Repository → Types → Mutation Hooks → 에러 함수 등록 순서로 진행하며,
+  각 단계 후 타입 검사와 lint를 수행한다.
+
+# ── Trigger ──────────────────────────────────────────────────────────────────
+trigger:
+  keywords:
+    - "CRUD 만들어"
+    - "CRUD 추가"
+    - "entities 만들어"
+    - "repository 만들어"
+  required_input:
+    - domain         # 단수 소문자 (예: quiz)
+    - endpoints      # HTTP method + path 목록
+    - request_body   # 요청 필드 정의
+    - response_item  # 응답 단건 필드 정의
+
+# ── Retrieval — 실행 전 읽어야 하는 문서 ─────────────────────────────────────
+retrieval:
+  required:
+    - docs/entities.md
+    - docs/architecture.md
+    - docs/error-handling.md
+  skills:
+    - .ai/skills/create-crud-flow.md
+    - .ai/skills/create-post-mutation.md
+    - .ai/skills/handle-api-error.md
+
+# ── Steps ────────────────────────────────────────────────────────────────────
+steps:
+  - id: read_docs
+    description: 실행 전 retrieval 문서를 읽고 패턴을 확인한다
+    action: read_files
+    files:
+      - docs/entities.md
+      - docs/architecture.md
+      - docs/error-handling.md
+
+  - id: generate_dto
+    description: DTO 스키마 및 payload 스키마 생성
+    action: run_skill
+    skill: create-crud-flow
+    phase: step_2_dto
+    output_file: "src/entities/{domain}/infrastructure/{domain}.dto.ts"
+    guardrails:
+      - dto와 payload를 반드시 분리 export
+      - DTO 타입을 features에서 직접 import 금지
+
+  - id: generate_keys
+    description: Query Key 팩토리 생성
+    action: run_skill
+    skill: create-crud-flow
+    phase: step_3_keys
+    output_file: "src/entities/{domain}/infrastructure/{domain}.keys.ts"
+    guardrails:
+      - queryKey 배열 리터럴 하드코딩 금지
+      - all prefix 필수
+
+  - id: generate_repository
+    description: Repository 생성 (API 호출 + 응답 파싱)
+    action: run_skill
+    skill: create-crud-flow
+    phase: step_4_repository
+    output_file: "src/entities/{domain}/infrastructure/{domain}.repository.ts"
+    guardrails:
+      - api.private / api.public 만 사용 (api.bff.* 금지)
+      - features import 절대 금지
+      - unwrapEnvelope 사용
+      - mutationFn 진입 전 payload.xxx.parse() 호출
+
+  - id: generate_types
+    description: UI 소비용 타입 내보내기
+    action: run_skill
+    skill: create-crud-flow
+    phase: step_5_types
+    output_file: "src/entities/{domain}/types/index.ts"
+    guardrails:
+      - DTO 타입 직접 export 금지
+      - z.infer<typeof dto.xxx> 형태만 허용
+
+  - id: typecheck_entities
+    description: entities 생성 후 타입 오류 확인
+    action: run_command
+    command: yarn tsc --noEmit
+    on_failure:
+      action: fix_and_retry
+      max_attempts: 2
+      hint: "타입 오류 메시지를 읽고 DTO / repository / types 파일을 수정한다"
+
+  - id: generate_classify_error
+    description: classify 에러 함수를 errors.ts에 추가
+    action: run_skill
+    skill: handle-api-error
+    phase: step_1_classify
+    target_file: "src/shared/lib/errors/errors.ts"
+    guardrails:
+      - 별도 파일 생성 금지 — errors.ts에만 추가
+      - FIELD / CONTEXT / AUTH / UNKNOWN 모두 포함
+
+  - id: generate_mutation_hooks
+    description: create / update / delete mutation hook 생성
+    action: run_skill
+    skill: create-post-mutation
+    output_dir: "src/features/{feature}/hooks/"
+    guardrails:
+      - hook 파일은 features/ 에만 위치
+      - onSuccess에 invalidateQueries 필수
+      - onError에 handleApiError 필수
+
+  - id: typecheck_final
+    description: 전체 타입 검사
+    action: run_command
+    command: yarn tsc --noEmit
+    on_failure:
+      action: fix_and_retry
+      max_attempts: 2
+
+  - id: lint
+    description: 린트 자동 수정
+    action: run_command
+    command: yarn lint --fix
+
+  - id: validate_guardrails
+    description: 레이어 위반 정적 검사
+    action: run_script
+    script: .ai/hooks/ai-check.sh
+    on_failure:
+      action: report_violation
+      message: "레이어 위반 감지. 아래 항목을 수정하고 다시 실행하세요."
+
+# ── Retry 정책 ────────────────────────────────────────────────────────────────
+retry:
+  typecheck:
+    max_attempts: 2
+    strategy: fix_errors_then_retry
+  lint:
+    max_attempts: 1
+    strategy: auto_fix
+
+# ── Restricted Paths — 이 워크플로우에서 수정 금지 ────────────────────────────
+restricted_paths:
+  - src/shared/api/http/         # HTTP 클라이언트 설정
+  - src/shared/lib/api-utils.ts  # unwrapEnvelope 구현
+  - src/shared/api/index.ts      # api export
+
+# ── 완료 조건 ─────────────────────────────────────────────────────────────────
+done_when:
+  - dto.ts 생성됨
+  - keys.ts 생성됨
+  - repository.ts 생성됨
+  - types/index.ts 갱신됨
+  - classify{Domain}Error가 errors.ts에 추가됨
+  - mutation hook 파일 생성됨
+  - yarn tsc --noEmit 통과
+  - yarn lint 통과
+  - 레이어 위반 없음

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,22 @@ When fixing bugs, follow the surrounding code's existing conventions.
 
 If any of the above rules cannot be applied, add a comment in the code explaining why.
 
+### 6. Prefer skill patterns over legacy implementations
+
+Existing legacy implementations may not follow the latest architecture rules.
+
+For newly generated code:
+- Prefer `.ai/skills/*` patterns
+- Do not copy legacy implementation patterns into new files
+
+### 7. Validate generated code before completion
+
+Before finishing any implementation, always run:
+
+1. `bash .ai/hooks/ai-check.sh`
+2. `yarn tsc --noEmit`
+3. `yarn lint`
+
 ---
 
 ## Quick Reference
@@ -76,3 +92,49 @@ IF the task involves writing or modifying E2E tests:
 
 IF you are unfamiliar with the codebase or the task spans multiple areas:
 → Read all 5 files in order (see Required Reading above)
+
+---
+
+## AI Harness
+
+For repetitive tasks, read the corresponding skill file and follow its steps exactly.
+
+| Task                                                                | Skill                                |
+| ------------------------------------------------------------------- | ------------------------------------ |
+| Create full CRUD for a new domain (DTO → keys → repository → types) | `.ai/skills/create-crud-flow.md`     |
+| Create a POST / PUT / PATCH / DELETE mutation hook                  | `.ai/skills/create-post-mutation.md` |
+| Add error handling to a mutation `onError`                          | `.ai/skills/handle-api-error.md`     |
+
+Workflows (orchestrate multiple skills in sequence):
+
+| Situation                 | Workflow                            |
+| ------------------------- | ----------------------------------- |
+| New domain CRUD requested | `.ai/workflows/crud_requested.yaml` |
+
+Run the layer violation check after any generation:
+
+```bash
+bash .ai/hooks/ai-check.sh
+```
+
+---
+
+## AI Workflow Rules
+
+IF creating a new domain CRUD:
+→ Read `.ai/skills/create-crud-flow.md` first
+→ Follow the order: DTO → keys → repository → types
+→ After generation, run in sequence:
+
+1.  `bash .ai/hooks/ai-check.sh`
+2.  `yarn tsc --noEmit`
+3.  `yarn lint`
+
+IF creating a mutation hook:
+→ Read `.ai/skills/create-post-mutation.md`
+→ `onSuccess` must call `invalidateQueries`
+→ `onError` must call `handleApiError`
+
+IF adding error handling:
+→ Read `.ai/skills/handle-api-error.md`
+→ Add `classifyXxxError` to `src/shared/lib/errors/errors.ts` — never in a separate file


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 린트 에러가 없습니다.
- [x] 코드가 올바르게 포맷팅되었습니다.
- [x] 빌드가 올바르게 실행되었습니다.

## 📌 변경 사항
<!-- 
- 변경된 내용에 대해 간략하게 설명해주세요.
- 예: 사용자 로그인 기능 추가
- 예: API 응답 구조 변경 
-->
### 목적
AI 에이전트가 코드를 생성할 때 아키텍처 규칙을 일관되게 따르도록 하네스(skills, workflow, guardrails)를 구축함.

### .ai/ 하네스 추가
- `skills/create-crud-flow.md` — DTO → keys → repository → types 생성 패턴
- `skills/create-post-mutation.md` — mutation hook 패턴 (폼 유무별 onError 위치)
- `skills/handle-api-error.md` — classifyXxxError + handleApiError 연결 패턴
- `workflows/crud_requested.yaml` — CRUD 전체 생성 시 실행되는 표준 워크플로우
- `hooks/ai-check.sh` — 레이어 위반 + tsc + lint 통합 검사 스크립트
- `hooks/guardrails.yaml` — pre/post write 규칙 및 수정 금지 경로 정의

### AGENTS.md 업데이트
- Rule 6: 신규 코드는 `.ai/skills/*` 패턴 우선
- Rule 7: 생성 완료 후 ai-check.sh 실행 의무화
- AI Harness 섹션 추가

  
## 🧐 관련 이슈
<!--
- 관련된 이슈 번호를 적어주세요. (ex. `Closes #123`, `Fixes #456`) 
-->
FE-7

## 📷 스크린샷 or 코드 (선택사항)
<!--
- UI 변경이 있거나 중요한 기능이 추가된 경우 스크린샷 또는 코드를 첨부해주세요.
-->

## 📚 참고 자료
<!--
- 참고한 자료나 링크가 있다면 적어주세요.
-->
https://www.notion.so/gaan/365fbb391d79802bb480db574836f066?source=copy_link